### PR TITLE
fix: remove `ProgramVersion` circular dependency

### DIFF
--- a/models/core/api.ts
+++ b/models/core/api.ts
@@ -5,7 +5,7 @@ import bs58 from 'bs58'
 import { ParsedAccount, ProgramAccountWithType } from '../core/accounts'
 import { Schema } from 'borsh'
 import { deserializeBorsh } from '../../utils/borsh'
-import { ProgramVersion } from '@models/registry/api'
+import { ProgramVersion } from 'models/registry/constants'
 import { SignerWalletAdapter } from '@solana/wallet-adapter-base'
 
 export const SYSTEM_PROGRAM_ID = new PublicKey(

--- a/models/registry/api.ts
+++ b/models/registry/api.ts
@@ -8,11 +8,7 @@ import devnetRealms from 'public/realms/devnet.json'
 import mainnetBetaRealms from 'public/realms/mainnet-beta.json'
 import { ConnectionContext } from 'stores/useWalletStore'
 import { equalsIgnoreCase } from '../../tools/core/strings'
-
-export enum ProgramVersion {
-  V1 = 1,
-  V2,
-}
+import { ProgramVersion } from './constants'
 
 export interface RealmInfo {
   symbol: string

--- a/models/registry/constants.ts
+++ b/models/registry/constants.ts
@@ -1,0 +1,4 @@
+export enum ProgramVersion {
+  V1 = 1,
+  V2,
+}

--- a/models/serialisation.ts
+++ b/models/serialisation.ts
@@ -44,7 +44,7 @@ import {
   VoteWeight,
 } from './accounts'
 import { serialize } from 'borsh'
-import { ProgramVersion } from './registry/api'
+import { ProgramVersion } from './registry/constants'
 ;(BinaryReader.prototype as any).readU16 = function () {
   const reader = (this as unknown) as BinaryReader
   const value = reader.buf.readUInt16LE(reader.offset)

--- a/models/withCreateRealm.ts
+++ b/models/withCreateRealm.ts
@@ -15,7 +15,7 @@ import {
   getTokenHoldingAddress,
   getRealmConfigAddress,
 } from './accounts'
-import { ProgramVersion } from 'models/registry/api'
+import { ProgramVersion } from 'models/registry/constants'
 import BN from 'bn.js'
 
 export async function withCreateRealm(

--- a/pages/realms/new.tsx
+++ b/pages/realms/new.tsx
@@ -16,7 +16,7 @@ import * as yup from 'yup'
 import { formValidation, isFormValid } from '@utils/formValidation'
 import { ProgramAccount, tryGetMint } from 'utils/tokens'
 import { MintInfo } from '@solana/spl-token'
-import { ProgramVersion } from '@models/registry/api'
+import { ProgramVersion } from 'models/registry/constants'
 import {
   getMintDecimalAmount,
   formatMintNaturalAmountAsDecimal,


### PR DESCRIPTION
While setting up tests I noticed there's a circular dependency which is causing some unexpected behaviour. 

Calls to `ProgramVersion.V1` will sometimes fail because `ProgramVersion === undefined` [when there are circular dependencies with enums](https://stackoverflow.com/a/59665223)

### before

<img width="668" alt="Screenshot 2021-12-16 at 10 32 21 PM" src="https://user-images.githubusercontent.com/601961/146458834-0c426a65-0530-4f07-9ed9-021d27a7aa89.png">

### after

<img width="668" alt="Screenshot 2021-12-16 at 10 31 57 PM" src="https://user-images.githubusercontent.com/601961/146458856-e37af577-2e47-49dd-a2f1-def6935bc13e.png">