### PR TITLE
globally disable `@typescript-eslint/no-non-null-assertion` rule

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -30,6 +30,7 @@
     "@typescript-eslint/indent": 0,
     "@typescript-eslint/member-delimiter-style": 0,
     "@typescript-eslint/ban-ts-comment": 0,
+    "@typescript-eslint/no-non-null-assertion": 0,
     "@typescript-eslint/no-explicit-any": 0,
     "@typescript-eslint/no-var-requires": 0,
     "@typescript-eslint/no-use-before-define": 0,

--- a/components/CancelProposalModal.tsx
+++ b/components/CancelProposalModal.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-non-null-assertion */
 import React from 'react'
 import { RpcContext } from 'models/core/api'
 import useWalletStore from 'stores/useWalletStore'

--- a/components/FinalizeVotesModal.tsx
+++ b/components/FinalizeVotesModal.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-non-null-assertion */
 import React from 'react'
 import { RpcContext } from 'models/core/api'
 import useWalletStore from 'stores/useWalletStore'

--- a/components/SignOffProposalModal.tsx
+++ b/components/SignOffProposalModal.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-non-null-assertion */
 import React from 'react'
 import { RpcContext } from 'models/core/api'
 import useWalletStore from 'stores/useWalletStore'

--- a/components/TokenBalanceCard.tsx
+++ b/components/TokenBalanceCard.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-non-null-assertion */
 import { MintInfo } from '@solana/spl-token'
 import {
   Account,

--- a/components/VoteCommentModal.tsx
+++ b/components/VoteCommentModal.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-non-null-assertion */
 import React, { FunctionComponent, useState } from 'react'
 import { postChatMessage } from '../actions/chat/postMessage'
 import { ChatMessageBody, ChatMessageBodyType } from '../models/chat/accounts'

--- a/components/VotePanel.tsx
+++ b/components/VotePanel.tsx
@@ -1,5 +1,3 @@
-/* eslint-disable @typescript-eslint/no-non-null-assertion */
-
 import { withFinalizeVote } from '@models/withFinalizeVote'
 import { TransactionInstruction } from '@solana/web3.js'
 import { useCallback, useEffect, useState } from 'react'
@@ -123,7 +121,6 @@ const VotePanel = () => {
       await relinquishVote(
         rpcContext,
         proposal!,
-        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
         voterTokenRecord!.pubkey,
         ownVoteRecord!.pubkey,
         instructions

--- a/components/chat/DiscussionForm.tsx
+++ b/components/chat/DiscussionForm.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-non-null-assertion */
 import { useState } from 'react'
 import Button from '../Button'
 import Input from '../inputs/Input'

--- a/components/explorer/inspectorButton.tsx
+++ b/components/explorer/inspectorButton.tsx
@@ -16,7 +16,6 @@ export default function InspectorButton({
   const showInspector = async () => {
     const result = await dryRunInstruction(
       connection.current,
-      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       wallet!,
       instructionData
     )

--- a/components/instructions/programs/splToken.tsx
+++ b/components/instructions/programs/splToken.tsx
@@ -44,7 +44,6 @@ export const SPL_TOKEN_INSTRUCTIONS = {
         )
         const tokenMint = await tryGetMint(
           connection,
-          // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
           tokenAccount!.account.mint
         )
 

--- a/hooks/useWallet.tsx
+++ b/hooks/useWallet.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-non-null-assertion */
 import { useEffect, useMemo } from 'react'
 
 import useWalletStore from '../stores/useWalletStore'

--- a/models/voteWeights.ts
+++ b/models/voteWeights.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-non-null-assertion */
 import BN from 'bn.js'
 import { MintInfo } from '@solana/spl-token'
 import BigNumber from 'bignumber.js'

--- a/models/withCreateSplTokenAccount.ts
+++ b/models/withCreateSplTokenAccount.ts
@@ -26,7 +26,6 @@ export const withCreateSplTokenAccount = async (
       provider,
       tokenAccount.publicKey,
       mint,
-      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       wallet!.publicKey!
     ))
   )

--- a/pages/dao/[symbol]/proposal/[pk].tsx
+++ b/pages/dao/[symbol]/proposal/[pk].tsx
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-non-null-assertion */
 import Link from 'next/link'
 import ReactMarkdown from 'react-markdown/react-markdown.min'
 import { ArrowLeftIcon, ExternalLinkIcon } from '@heroicons/react/outline'

--- a/pages/dao/[symbol]/proposal/components/DryRunInstructionBtn.tsx
+++ b/pages/dao/[symbol]/proposal/components/DryRunInstructionBtn.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-non-null-assertion */
 import Button, { LinkButton, SecondaryButton } from '@components/Button'
 import { getExplorerInspectorUrl } from '@components/explorer/tools'
 import Loading from '@components/Loading'

--- a/pages/dao/[symbol]/proposal/components/instructions/CustomBase64.tsx
+++ b/pages/dao/[symbol]/proposal/components/instructions/CustomBase64.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-non-null-assertion */
 import React, { useContext, useEffect, useState } from 'react'
 import * as yup from 'yup'
 import {

--- a/pages/dao/[symbol]/proposal/components/instructions/Empty.tsx
+++ b/pages/dao/[symbol]/proposal/components/instructions/Empty.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-non-null-assertion */
 import React, { useContext, useEffect, useState } from 'react'
 import * as yup from 'yup'
 import {

--- a/pages/dao/[symbol]/proposal/components/instructions/Execute.tsx
+++ b/pages/dao/[symbol]/proposal/components/instructions/Execute.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-non-null-assertion */
 import React from 'react'
 import { RpcContext } from 'models/core/api'
 import useWalletStore from 'stores/useWalletStore'

--- a/pages/dao/[symbol]/proposal/components/instructions/Mint.tsx
+++ b/pages/dao/[symbol]/proposal/components/instructions/Mint.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-non-null-assertion */
 import React, { useContext, useEffect, useState } from 'react'
 import Input from '@components/inputs/Input'
 import useRealm from '@hooks/useRealm'

--- a/pages/dao/[symbol]/proposal/components/instructions/ProgramUpgrade.tsx
+++ b/pages/dao/[symbol]/proposal/components/instructions/ProgramUpgrade.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-non-null-assertion */
 import React, { useContext, useEffect, useState } from 'react'
 import useRealm from '@hooks/useRealm'
 import { PublicKey } from '@solana/web3.js'

--- a/pages/dao/[symbol]/proposal/components/instructions/SplTokenTransfer.tsx
+++ b/pages/dao/[symbol]/proposal/components/instructions/SplTokenTransfer.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-non-null-assertion */
 import React, { useContext, useEffect, useState } from 'react'
 import Input from '@components/inputs/Input'
 import useRealm from '@hooks/useRealm'

--- a/scripts/governance-notifier.ts
+++ b/scripts/governance-notifier.ts
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-non-null-assertion */
 import { PublicKey } from '@solana/web3.js'
 import axios from 'axios'
 import { getConnectionContext } from 'stores/useWalletStore'

--- a/stores/useWalletStore.tsx
+++ b/stores/useWalletStore.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable @typescript-eslint/no-non-null-assertion */
 import create, { State } from 'zustand'
 import produce from 'immer'
 import { Connection, PublicKey } from '@solana/web3.js'

--- a/utils/send.tsx
+++ b/utils/send.tsx
@@ -14,7 +14,6 @@ class TransactionError extends Error {
   public txid: string
   constructor(message: string, txid?: string) {
     super(message)
-    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     this.txid = txid!
   }
 }

--- a/utils/tokens.tsx
+++ b/utils/tokens.tsx
@@ -67,7 +67,6 @@ export async function tryGetMint(
 ): Promise<ProgramAccount<MintAccount> | undefined> {
   try {
     const result = await connection.getAccountInfo(publicKey)
-    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     const data = Buffer.from(result!.data)
     const account = parseMintAccountData(data)
     return {
@@ -90,7 +89,6 @@ export async function tryGetTokenAccount(
       return undefined
     }
 
-    // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     const data = Buffer.from(result!.data)
     const account = parseTokenAccountData(publicKey, data)
     return {
@@ -249,7 +247,6 @@ export function getTokenAccountLabelInfo(
     tokenName = info?.name ? info.name : ''
     tokenAccountName = getAccountName(acc.token.publicKey)
     amount = formatMintNaturalAmountAsDecimal(
-      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       acc.mint!.account,
       acc.token?.account.amount
     )
@@ -280,7 +277,6 @@ export function getMintAccountLabelInfo(
     tokenName = info?.name ? info.name : ''
     mintAccountName = getAccountName(acc.governance.info.governedAccount)
     amount = formatMintNaturalAmountAsDecimal(
-      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
       acc.mintInfo,
       acc?.mintInfo.supply
     )


### PR DESCRIPTION
this removes a lot of code comments and all existing warnings from eslint about using `variable!`