### PR TITLE
refactor: remove duplicated and unused code

### DIFF
--- a/models/core/api.ts
+++ b/models/core/api.ts
@@ -48,13 +48,7 @@ export class RpcContext {
 }
 
 export class MemcmpFilter {
-  offset: number
-  bytes: Buffer
-
-  constructor(offset: number, bytes: Buffer) {
-    this.offset = offset
-    this.bytes = bytes
-  }
+  constructor(public offset: number, public bytes: Buffer) {}
 
   isMatch(buffer: Buffer) {
     if (this.offset + this.bytes.length > buffer.length) {

--- a/scripts/api.ts
+++ b/scripts/api.ts
@@ -14,10 +14,6 @@ import { deserializeBorsh } from 'utils/borsh'
 
 const fetch = require('node-fetch')
 
-export interface IWallet {
-  publicKey: PublicKey
-}
-
 export const pubkeyFilter = (offset: number, pubkey: PublicKey) =>
   new MemcmpFilter(offset, pubkey.toBuffer())
 

--- a/scripts/api.ts
+++ b/scripts/api.ts
@@ -1,15 +1,16 @@
 import { PublicKey } from '@solana/web3.js'
-import { SanitizedObject } from '@utils/helpers'
+import { SanitizedObject } from 'utils/helpers'
 import * as bs58 from 'bs58'
 import {
   GovernanceAccount,
   GovernanceAccountClass,
   GovernanceAccountType,
   Realm,
-} from '../models/accounts'
-import { ParsedAccount } from '../models/core/accounts'
-import { GOVERNANCE_SCHEMA } from '../models/serialisation'
-import { deserializeBorsh } from '../utils/borsh'
+} from 'models/accounts'
+import { ParsedAccount } from 'models/core/accounts'
+import { MemcmpFilter, RpcContext } from 'models/core/api'
+import { GOVERNANCE_SCHEMA } from 'models/serialisation'
+import { deserializeBorsh } from 'utils/borsh'
 
 const fetch = require('node-fetch')
 

--- a/scripts/api.ts
+++ b/scripts/api.ts
@@ -11,6 +11,7 @@ import { ParsedAccount } from 'models/core/accounts'
 import { MemcmpFilter, RpcContext } from 'models/core/api'
 import { GOVERNANCE_SCHEMA } from 'models/serialisation'
 import { deserializeBorsh } from 'utils/borsh'
+import { sleep } from '@project-serum/common'
 
 const fetch = require('node-fetch')
 
@@ -54,7 +55,7 @@ export async function getGovernanceAccounts<TAccount extends GovernanceAccount>(
       )),
     }
     // XXX: sleep to prevent public RPC rate limits
-    await new Promise((r) => setTimeout(r, 3_000))
+    await sleep(3_000)
   }
 
   return accounts

--- a/scripts/api.ts
+++ b/scripts/api.ts
@@ -14,9 +14,6 @@ import { deserializeBorsh } from 'utils/borsh'
 
 const fetch = require('node-fetch')
 
-export const pubkeyFilter = (offset: number, pubkey: PublicKey) =>
-  new MemcmpFilter(offset, pubkey.toBuffer())
-
 export async function getRealms(rpcContext: RpcContext) {
   return getGovernanceAccountsImpl<Realm>(
     rpcContext.programId,

--- a/scripts/api.ts
+++ b/scripts/api.ts
@@ -8,7 +8,6 @@ import {
   Realm,
 } from '../models/accounts'
 import { ParsedAccount } from '../models/core/accounts'
-import { RpcContext } from '../models/core/api'
 import { GOVERNANCE_SCHEMA } from '../models/serialisation'
 import { deserializeBorsh } from '../utils/borsh'
 
@@ -16,28 +15,6 @@ const fetch = require('node-fetch')
 
 export interface IWallet {
   publicKey: PublicKey
-}
-
-export class MemcmpFilter {
-  offset: number
-  bytes: Buffer
-
-  constructor(offset: number, bytes: Buffer) {
-    this.offset = offset
-    this.bytes = bytes
-  }
-
-  isMatch(buffer: Buffer) {
-    if (this.offset + this.bytes.length > buffer.length) {
-      return false
-    }
-
-    for (let i = 0; i < this.bytes.length; i++) {
-      if (this.bytes[i] !== buffer[this.offset + i]) return false
-    }
-
-    return true
-  }
 }
 
 export const pubkeyFilter = (offset: number, pubkey: PublicKey) =>

--- a/scripts/governance-notifier.ts
+++ b/scripts/governance-notifier.ts
@@ -1,10 +1,11 @@
 import { PublicKey } from '@solana/web3.js'
 import axios from 'axios'
 import { getConnectionContext } from 'utils/connection'
+import { pubkeyFilter } from 'models/core/api'
 import { getAccountTypes, Governance, Proposal } from '../models/accounts'
 import { ParsedAccount } from '../models/core/accounts'
 import { getCertifiedRealmInfo } from '../models/registry/api'
-import { getGovernanceAccounts, pubkeyFilter } from './api'
+import { getGovernanceAccounts } from './api'
 
 const fiveMinutesSeconds = 5 * 60
 const toleranceSeconds = 30

--- a/stores/useWalletStore.tsx
+++ b/stores/useWalletStore.tsx
@@ -31,7 +31,6 @@ import {
 import { DEFAULT_PROVIDER } from '../utils/wallet-adapters'
 import { ParsedAccount } from '../models/core/accounts'
 import { fetchGistFile } from '../utils/github'
-import { pubkeyFilter } from '../scripts/api'
 import { getGovernanceChatMessages } from '../models/chat/api'
 import { ChatMessage } from '../models/chat/accounts'
 import { mapFromEntries, mapEntries } from '../tools/core/script'
@@ -43,6 +42,7 @@ import { getCertifiedRealmInfo } from '@models/registry/api'
 import { tryParsePublicKey } from '@tools/core/pubkey'
 import type { ConnectionContext } from 'utils/connection'
 import { getConnectionContext } from 'utils/connection'
+import { pubkeyFilter } from 'models/core/api'
 
 interface WalletStore extends State {
   connected: boolean

--- a/utils/send.tsx
+++ b/utils/send.tsx
@@ -9,6 +9,7 @@ import {
   TransactionSignature,
 } from '@solana/web3.js'
 import Wallet from '@project-serum/sol-wallet-adapter'
+import { sleep } from '@project-serum/common'
 
 class TransactionError extends Error {
   public txid: string
@@ -16,10 +17,6 @@ class TransactionError extends Error {
     super(message)
     this.txid = txid!
   }
-}
-
-export async function sleep(ms) {
-  return new Promise((resolve) => setTimeout(resolve, ms))
 }
 
 export function getUnixTs() {


### PR DESCRIPTION
- removes duplicate code from `scripts/api.ts`
- imports sleep from `@project-serum/common`
- removes the preceding @ from some local imports. The plan is to remove the paths object from tsconfig as baseUrl is set to "." anyway. This will help with simplifying intellisense suggestions and consistency across the project.