### PR TITLE
fix: broken wallet modal, form input widths and create button to the …

### DIFF
--- a/components/RealmWizard/RealmWizard.tsx
+++ b/components/RealmWizard/RealmWizard.tsx
@@ -199,7 +199,14 @@ const RealmWizard: React.FC = () => {
   }, [currentStep, form])
 
   return (
-    <div className="relative">
+    <div
+      className="relative w-full"
+      style={
+        ctl && ctl.getCurrentStep() !== RealmWizardStep.SELECT_MODE
+          ? { maxWidth: 512 }
+          : undefined
+      }
+    >
       <div className="pointer">
         <a
           className="flex items-center text-fgd-3 text-sm transition-all hover:text-fgd-1"
@@ -218,7 +225,7 @@ const RealmWizard: React.FC = () => {
         BoundStepComponent
       )}
       {ctl && !(ctl.isFirstStep() || isLoading) && (
-        <>
+        <div className="flex justify-end pr-10 mr-3">
           <Button
             onClick={() => {
               if (ctl.isLastStep()) handleCreateRealm()
@@ -228,7 +235,7 @@ const RealmWizard: React.FC = () => {
           >
             {ctl.isLastStep() ? 'Create' : 'Next'}
           </Button>
-        </>
+        </div>
       )}
     </div>
   )

--- a/components/RealmWizard/components/AddWalletModal.tsx
+++ b/components/RealmWizard/components/AddWalletModal.tsx
@@ -13,23 +13,27 @@ const AddWalletModal: React.FC<{
   const [hasErrors, setErrors] = useState<string[]>()
 
   const handleAddWallet = () => {
-    const wallets = walletAddr.replace(/ /gim, '').split(/,|\n/gim)
+    const wallets = walletAddr.replace(/ +/gim, '').split(/,|\n/gim)
     const errors: string[] = []
+    const parsedWallets: string[] = []
     wallets.forEach((wallet, index) => {
-      if (!publicKeyValidationTest(wallet)) {
-        errors.push(
-          `Entry ${index + 1} (${wallet.substr(
-            0,
-            8
-          )}...)  is not a valid public key.`
-        )
+      if (wallet.length) {
+        parsedWallets.push(wallet)
+        if (!publicKeyValidationTest(wallet)) {
+          errors.push(
+            `Entry ${index + 1} (${wallet.substr(
+              0,
+              8
+            )}...)  is not a valid public key.`
+          )
+        }
       }
     })
     if (errors.length) setErrors(errors)
     else {
       onClose()
       setWalletAddr('')
-      onOk(wallets)
+      onOk(parsedWallets)
     }
   }
 

--- a/components/RealmWizard/components/Steps/StepOne.tsx
+++ b/components/RealmWizard/components/Steps/StepOne.tsx
@@ -40,7 +40,7 @@ const StepOne: React.FC<RealmWizardStepComponentProps> = ({
 
   return (
     <div>
-      <div className="pb-4 my-5">
+      <div className="pb-4 my-5 pr-10 w-full" style={{ maxWidth: 512 }}>
         <StyledLabel>Name your realm</StyledLabel>
         <Input
           required
@@ -56,6 +56,19 @@ const StepOne: React.FC<RealmWizardStepComponentProps> = ({
       </div>
       <div className="pb-7 pr-10 w-full" style={{ maxWidth: 512 }}>
         <StyledLabel>Approval quorum (%)</StyledLabel>
+        <Input
+          required
+          type="number"
+          value={form.yesThreshold}
+          min={1}
+          max={100}
+          onChange={($e) => {
+            setForm({
+              yesThreshold: $e.target.value,
+            })
+          }}
+        />
+        <div className="pb-5" />
         <AmountSlider
           step={1}
           value={form.yesThreshold ?? 0}

--- a/components/RealmWizard/components/Steps/StepOne.tsx
+++ b/components/RealmWizard/components/Steps/StepOne.tsx
@@ -62,9 +62,24 @@ const StepOne: React.FC<RealmWizardStepComponentProps> = ({
           value={form.yesThreshold}
           min={1}
           max={100}
+          onBlur={() => {
+            if (
+              !form.yesThreshold ||
+              form.yesThreshold.toString().match(/\D+/gim)
+            ) {
+              setForm({
+                yesThreshold: 60,
+              })
+            }
+          }}
           onChange={($e) => {
+            let yesThreshold = $e.target.value
+            if (yesThreshold.length) {
+              yesThreshold =
+                +yesThreshold < 1 ? 1 : +yesThreshold > 100 ? 100 : yesThreshold
+            }
             setForm({
-              yesThreshold: $e.target.value,
+              yesThreshold,
             })
           }}
         />

--- a/components/RealmWizard/components/TeamWalletField.tsx
+++ b/components/RealmWizard/components/TeamWalletField.tsx
@@ -88,7 +88,7 @@ const TeamWalletField: React.FC<{
           setShowWalletModal(false)
         }}
       />
-      <div className="flex justify-center pr-10 mr-5">{newWalletButton}</div>
+      <div className="flex justify-start">{newWalletButton}</div>
     </div>
   )
 }

--- a/components/RealmWizard/components/TeamWalletField.tsx
+++ b/components/RealmWizard/components/TeamWalletField.tsx
@@ -16,7 +16,7 @@ const TeamWalletField: React.FC<{
 
   const newWalletButton = (
     <div
-      className="add-wallet-btn pointer pt-1.5 w-10 h-10 mt-4 flex justify-center align-center"
+      className="add-wallet-btn pointer w-10 h-10"
       onClick={() => {
         setShowWalletModal(true)
       }}
@@ -88,7 +88,7 @@ const TeamWalletField: React.FC<{
           setShowWalletModal(false)
         }}
       />
-      {newWalletButton}
+      <div className="flex justify-center pr-10 mr-5">{newWalletButton}</div>
     </div>
   )
 }


### PR DESCRIPTION
### Changelog

 - [X] The add wallet textfield logic was changed. `\n` was breaking it
 - [X] Set a max-width to the form
 - [X] Added a field to display the quorum percent value
 
Current look: 
![image](https://user-images.githubusercontent.com/10161518/147303124-1c32bce7-fba5-4efe-a282-576a64087bc5.png)
