### PR TITLE
chore: enforce valid GOVERNANCE_SCHEMA keys with types

### DIFF
--- a/models/serialisation.ts
+++ b/models/serialisation.ts
@@ -93,7 +93,7 @@ export function getGovernanceSchema(programVersion: ProgramVersion) {
 }
 
 function createGovernanceSchema(programVersion: ProgramVersion) {
-  return new Map<any, any>([
+  const schemaData = [
     [
       RealmConfigArgs,
       {
@@ -518,7 +518,10 @@ function createGovernanceSchema(programVersion: ProgramVersion) {
         ],
       },
     ],
-  ])
+  ] as const
+
+  // only allow valid class keys to be used when accessing Map
+  return new Map<typeof schemaData[number][0], any>(schemaData)
 }
 
 export function getInstructionDataFromBase64(instructionDataBase64: string) {


### PR DESCRIPTION
A mini DX update which will only allow valid classes to be used as keys when accessing `GOVERNMENT_SCHEMA`

currently anything can be used as a key because of the `Map<any,any>` type, this makes it a bit stricter and typescript will warn if trying to access a key that doesn't exist.

## before
![Screenshot 2021-12-27 at 12 08 05 PM](https://user-images.githubusercontent.com/601961/147470762-65061b36-b064-4f5a-a646-6a084ab43c77.png)

## after
![Screenshot 2021-12-27 at 12 06 25 PM](https://user-images.githubusercontent.com/601961/147470768-accfb937-59a1-47d1-b441-3d3a0710be96.png)
