### PR TITLE
Feat/bespoke multistep

### DIFF
--- a/.github/workflows/deploy-docs.yml
+++ b/.github/workflows/deploy-docs.yml
@@ -18,7 +18,7 @@ jobs:
       # interfere with the build process for the docs
       - name: Remove root postcss config
         run: rm postcss.config.js
-        
+
       - name: Build docs
         working-directory: docs
         run: |

--- a/actions/createMultisigRealm.ts
+++ b/actions/createMultisigRealm.ts
@@ -93,6 +93,7 @@ export const createMultisigRealm = async (
       teamWalletPk,
       walletPk
     )
+
     // Mint 1 council token to each team member
     await withMintTo(
       councilMembersInstructions,

--- a/actions/registerRealm.ts
+++ b/actions/registerRealm.ts
@@ -11,12 +11,7 @@ import { withCreateRealm } from '../models/withCreateRealm'
 import { RpcContext } from '../models/core/api'
 import { sendTransaction } from '../utils/send'
 import { ProgramVersion } from '@models/registry/constants'
-import {
-  getWalletPublicKey,
-  sendTransactions,
-  SequenceType,
-  WalletSigner,
-} from 'utils/sendTransactions'
+import { sendTransactions, SequenceType } from 'utils/sendTransactions'
 import { withCreateMint } from '@tools/sdk/splToken/withCreateMint'
 import { withCreateAssociatedTokenAccount } from '@tools/sdk/splToken/withCreateAssociatedTokenAccount'
 import { withMintTo } from '@tools/sdk/splToken/withMintTo'

--- a/actions/registerRealm.ts
+++ b/actions/registerRealm.ts
@@ -103,7 +103,6 @@ export async function registerRealm(
   councilWalletPks?: PublicKey[]
 ): Promise<PublicKey> {
   const realmInstructions: TransactionInstruction[] = []
-  let tokenOwnerRecordPk: PublicKey | undefined = undefined
 
   const {
     councilMintPk,

--- a/actions/registerRealm.ts
+++ b/actions/registerRealm.ts
@@ -1,4 +1,5 @@
 import {
+  Connection,
   Keypair,
   PublicKey,
   Transaction,
@@ -21,25 +22,29 @@ import { withCreateAssociatedTokenAccount } from '@tools/sdk/splToken/withCreate
 import { withMintTo } from '@tools/sdk/splToken/withMintTo'
 import { chunks } from '@utils/helpers'
 import { WalletConnectionError } from '@solana/wallet-adapter-base'
-export async function registerRealm(
-  { connection, wallet, walletPubkey }: RpcContext,
-  programId: PublicKey,
-  programVersion: ProgramVersion,
-  name: string,
-  communityMint: PublicKey,
-  councilMint: PublicKey | undefined,
-  communityMintMaxVoteWeightSource: MintMaxVoteWeightSource,
-  minCommunityTokensToCreateGovernance: BN,
+import { withDepositGoverningTokens } from '@models/withDepositGoverningTokens'
+
+/**
+ * Prepares the council instructions
+ * @param connection
+ * @param walletPubkey
+ * @param councilMint
+ * @param councilWalletPks
+ */
+async function prepareCouncilInstructions(
+  connection: Connection,
+  walletPubkey: PublicKey,
+  councilMint?: PublicKey,
   councilWalletPks?: PublicKey[]
-): Promise<PublicKey> {
-  const instructions: TransactionInstruction[] = []
+) {
+  let councilMintPk: PublicKey | undefined = undefined
+  let walletAtaPk: PublicKey | undefined
   const councilMintInstructions: TransactionInstruction[] = []
   const councilMintSigners: Keypair[] = []
 
   // If the array of council wallets is not empty
   // then should create mints to the council
-  if (councilWalletPks) {
-    let councilMintPk: PublicKey
+  if (councilWalletPks && councilWalletPks.length) {
     // If councilMint is undefined, then
     // should create the council mint
     councilMintPk =
@@ -53,8 +58,6 @@ export async function registerRealm(
         0,
         walletPubkey
       ))
-
-    let walletAtaPk: PublicKey | undefined
 
     for (const teamWalletPk of councilWalletPks) {
       const ataPk = await withCreateAssociatedTokenAccount(
@@ -79,38 +82,95 @@ export async function registerRealm(
     }
   }
 
+  const councilMembersChunks = chunks(councilMintInstructions, 10)
+  // only walletPk needs to sign the minting instructions and it's a signer by default and we don't have to include any more signers
+  const councilSignersChunks = Array(councilMembersChunks.length).fill(
+    councilMintSigners
+  )
+
+  return {
+    councilMintPk,
+    walletAtaPk,
+    councilMembersChunks,
+    councilSignersChunks,
+  }
+}
+
+export async function registerRealm(
+  { connection, wallet, walletPubkey }: RpcContext,
+  programId: PublicKey,
+  programVersion: ProgramVersion,
+  name: string,
+  communityMint: PublicKey,
+  councilMint: PublicKey | undefined,
+  communityMintMaxVoteWeightSource: MintMaxVoteWeightSource,
+  minCommunityTokensToCreateGovernance: BN,
+  councilWalletPks?: PublicKey[]
+): Promise<PublicKey> {
+  const realmInstructions: TransactionInstruction[] = []
+  let tokenOwnerRecordPk: PublicKey | undefined = undefined
+
+  const {
+    councilMintPk,
+    walletAtaPk,
+    councilMembersChunks,
+    councilSignersChunks,
+  } = await prepareCouncilInstructions(
+    connection,
+    walletPubkey,
+    councilMint,
+    councilWalletPks
+  )
+
   const realmAddress = await withCreateRealm(
-    instructions,
+    realmInstructions,
     programId,
     programVersion,
     name,
     walletPubkey,
     communityMint,
     walletPubkey,
-    councilMint,
+    councilMintPk,
     communityMintMaxVoteWeightSource,
     minCommunityTokensToCreateGovernance,
     undefined
   )
 
-  const transaction = new Transaction()
-  transaction.add(...instructions)
+  // If the current wallet is in the team then deposit the council token
+  if (councilMintPk)
+    if (walletAtaPk) {
+      tokenOwnerRecordPk = await withDepositGoverningTokens(
+        realmInstructions,
+        programId,
+        realmAddress,
+        walletAtaPk,
+        councilMintPk,
+        walletPubkey,
+        walletPubkey,
+        walletPubkey
+      )
+    } else {
+      // Let's throw for now if the current wallet isn't in the team
+      // TODO: To fix it we would have to make it temp. as part of the team and then remove after the realm is created
+      throw new Error('Current wallet must be in the team')
+    }
 
-  const councilMembersChunks = chunks(councilMintInstructions, 10)
-  // only walletPk needs to sign the minting instructions and it's a signer by default and we don't have to include any more signers
-  const councilMembersSignersChunks = Array(councilMembersChunks.length).fill(
-    []
-  )
+  const transaction = new Transaction()
+  transaction.add(...realmInstructions)
+
   if (!wallet) throw WalletConnectionError
 
-  await sendTransactions(
-    connection,
-    wallet,
-    [...councilMembersChunks, instructions],
-    [...councilMembersSignersChunks, []],
-    SequenceType.Sequential
-  )
+  if (councilMembersChunks.length) {
+    await sendTransactions(
+      connection,
+      wallet,
+      [...councilMembersChunks, realmInstructions],
+      [...councilSignersChunks, []],
+      SequenceType.Sequential
+    )
+  } else {
+    await sendTransaction({ transaction, wallet, connection })
+  }
 
-  // await sendTransaction({ transaction, wallet, connection })
   return realmAddress
 }

--- a/actions/registerRealm.ts
+++ b/actions/registerRealm.ts
@@ -134,7 +134,7 @@ export async function registerRealm(
   // If the current wallet is in the team then deposit the council token
   if (councilMintPk)
     if (walletAtaPk) {
-      tokenOwnerRecordPk = await withDepositGoverningTokens(
+      await withDepositGoverningTokens(
         realmInstructions,
         programId,
         realmAddress,

--- a/actions/registerRealm.ts
+++ b/actions/registerRealm.ts
@@ -1,11 +1,26 @@
-import { PublicKey, Transaction, TransactionInstruction } from '@solana/web3.js'
+import {
+  Keypair,
+  PublicKey,
+  Transaction,
+  TransactionInstruction,
+} from '@solana/web3.js'
 import BN from 'bn.js'
 import { MintMaxVoteWeightSource } from '../models/accounts'
 import { withCreateRealm } from '../models/withCreateRealm'
 import { RpcContext } from '../models/core/api'
 import { sendTransaction } from '../utils/send'
 import { ProgramVersion } from '@models/registry/constants'
-
+import {
+  getWalletPublicKey,
+  sendTransactions,
+  SequenceType,
+  WalletSigner,
+} from 'utils/sendTransactions'
+import { withCreateMint } from '@tools/sdk/splToken/withCreateMint'
+import { withCreateAssociatedTokenAccount } from '@tools/sdk/splToken/withCreateAssociatedTokenAccount'
+import { withMintTo } from '@tools/sdk/splToken/withMintTo'
+import { chunks } from '@utils/helpers'
+import { WalletConnectionError } from '@solana/wallet-adapter-base'
 export async function registerRealm(
   { connection, wallet, walletPubkey }: RpcContext,
   programId: PublicKey,
@@ -14,9 +29,55 @@ export async function registerRealm(
   communityMint: PublicKey,
   councilMint: PublicKey | undefined,
   communityMintMaxVoteWeightSource: MintMaxVoteWeightSource,
-  minCommunityTokensToCreateGovernance: BN
+  minCommunityTokensToCreateGovernance: BN,
+  councilWalletPks?: PublicKey[]
 ): Promise<PublicKey> {
   const instructions: TransactionInstruction[] = []
+  const councilMintInstructions: TransactionInstruction[] = []
+  const councilMintSigners: Keypair[] = []
+
+  // If the array of council wallets is not empty
+  // then should create mints to the council
+  if (councilWalletPks) {
+    let councilMintPk: PublicKey
+    // If councilMint is undefined, then
+    // should create the council mint
+    councilMintPk =
+      councilMint ??
+      (await withCreateMint(
+        connection,
+        councilMintInstructions,
+        councilMintSigners,
+        walletPubkey,
+        null,
+        0,
+        walletPubkey
+      ))
+
+    let walletAtaPk: PublicKey | undefined
+
+    for (const teamWalletPk of councilWalletPks) {
+      const ataPk = await withCreateAssociatedTokenAccount(
+        councilMintInstructions,
+        councilMintPk,
+        teamWalletPk,
+        walletPubkey
+      )
+
+      // Mint 1 council token to each team member
+      await withMintTo(
+        councilMintInstructions,
+        councilMintPk,
+        ataPk,
+        walletPubkey,
+        1
+      )
+
+      if (teamWalletPk.equals(walletPubkey)) {
+        walletAtaPk = ataPk
+      }
+    }
+  }
 
   const realmAddress = await withCreateRealm(
     instructions,
@@ -35,6 +96,21 @@ export async function registerRealm(
   const transaction = new Transaction()
   transaction.add(...instructions)
 
-  await sendTransaction({ transaction, wallet, connection })
+  const councilMembersChunks = chunks(councilMintInstructions, 10)
+  // only walletPk needs to sign the minting instructions and it's a signer by default and we don't have to include any more signers
+  const councilMembersSignersChunks = Array(councilMembersChunks.length).fill(
+    []
+  )
+  if (!wallet) throw WalletConnectionError
+
+  await sendTransactions(
+    connection,
+    wallet,
+    [...councilMembersChunks, instructions],
+    [...councilMembersSignersChunks, []],
+    SequenceType.Sequential
+  )
+
+  // await sendTransaction({ transaction, wallet, connection })
   return realmAddress
 }

--- a/components/RealmWizard/RealmWizard.tsx
+++ b/components/RealmWizard/RealmWizard.tsx
@@ -28,7 +28,6 @@ import { createMultisigRealm } from 'actions/createMultisigRealm'
 import { ArrowLeftIcon } from '@heroicons/react/solid'
 import useQueryContext from '@hooks/useQueryContext'
 import router from 'next/router'
-import CreateRealmForm from './components/CreateRealmForm'
 import { useEffect } from 'react'
 import { CreateFormSchema } from './validators/createRealmValidator'
 import { formValidation, isFormValid } from '@utils/formValidation'
@@ -59,15 +58,13 @@ const RealmWizard: React.FC = () => {
   const [form, setForm] = useState<RealmArtifacts>({
     yesThreshold: 60,
   })
-  const [formErrors, setFormErrors] = useState({})
+  const [, setFormErrors] = useState({})
   const [isLoading, setIsLoading] = useState(false)
   const [currentStep, setCurrentStep] = useState<RealmWizardStep>(
     RealmWizardStep.SELECT_MODE
   )
   const [realmAddress] = useState('')
-  const [loaderMessage, setLoaderMessage] = useState<LoaderMessage>(
-    LoaderMessage.DEPLOYING_REALM
-  )
+  const [loaderMessage] = useState<LoaderMessage>(LoaderMessage.DEPLOYING_REALM)
 
   // TODO: This state will be removed in future versions
   const [shouldFireCreate, setShouldFireCreate] = useState(false)

--- a/components/RealmWizard/RealmWizard.tsx
+++ b/components/RealmWizard/RealmWizard.tsx
@@ -45,6 +45,8 @@ enum LoaderMessage {
   ERROR = 'We found an error while creating your Realm :/',
 }
 
+// TODO: split this component
+
 const RealmWizard: React.FC = () => {
   const { fmtUrlWithCluster } = useQueryContext()
   // const wallet = useWalletStore((s) => s.current)
@@ -64,9 +66,6 @@ const RealmWizard: React.FC = () => {
   )
   const [realmAddress] = useState('')
   const [loaderMessage] = useState<LoaderMessage>(LoaderMessage.DEPLOYING_REALM)
-
-  // TODO: This state will be removed in future versions
-  const [shouldFireCreate, setShouldFireCreate] = useState(false)
 
   /**
    * Handles and set the form data

--- a/components/RealmWizard/RealmWizard.tsx
+++ b/components/RealmWizard/RealmWizard.tsx
@@ -133,6 +133,7 @@ const RealmWizard: React.FC = () => {
 
   const handleCreateBespokeRealm = async () => {
     setFormErrors({})
+
     const { isValid, validationErrors }: formValidation = await isFormValid(
       CreateFormSchema,
       form
@@ -154,7 +155,10 @@ const RealmWizard: React.FC = () => {
         new PublicKey(form.communityMintId!),
         form.councilMintId ? new PublicKey(form.councilMintId) : undefined,
         MintMaxVoteWeightSource.FULL_SUPPLY_FRACTION,
-        form.minCommunityTokensToCreateGovernance!
+        form.minCommunityTokensToCreateGovernance!,
+        form.teamWallets
+          ? form.teamWallets.map((w) => new PublicKey(w))
+          : undefined
       )
       router.push(fmtUrlWithCluster(`/dao/${realmAddress.toBase58()}`))
     } else {
@@ -170,7 +174,12 @@ const RealmWizard: React.FC = () => {
     try {
       const ctl = new RealmWizardController(option)
       const nextStep = ctl.getNextStep(currentStep, StepDirection.NEXT)
-      console.log(ctl)
+      setForm({
+        governanceProgramId:
+          process.env.DEFAULT_GOVERNANCE_PROGRAM_ID ??
+          DEFAULT_GOVERNANCE_PROGRAM_ID,
+        yesThreshold: 60,
+      })
       setController(ctl)
       setCurrentStep(nextStep)
     } catch (error) {
@@ -313,15 +322,6 @@ const RealmWizard: React.FC = () => {
     // Return shouldFireCreate to the base state
     if (Object.values(formErrors).length) setFormErrors({})
   }, [form])
-
-  useEffect(() => {
-    setForm({
-      governanceProgramId:
-        process.env.DEFAULT_GOVERNANCE_PROGRAM_ID ??
-        DEFAULT_GOVERNANCE_PROGRAM_ID,
-      yesThreshold: 60,
-    })
-  }, [])
 
   return (
     <div

--- a/components/RealmWizard/components/ApprovalQuorumInput.tsx
+++ b/components/RealmWizard/components/ApprovalQuorumInput.tsx
@@ -1,0 +1,41 @@
+import React from 'react'
+import Input from '@components/inputs/Input'
+import { StyledLabel } from '@components/inputs/styles'
+import AmountSlider from '@components/Slider'
+
+const ApprovalQuorumInput: React.FC<{
+  onChange: (amount: number) => void
+  onBlur?: () => void
+  value?: number
+}> = ({ onChange, onBlur, value }) => {
+  return (
+    <>
+      <StyledLabel>Approval quorum (%)</StyledLabel>
+      <Input
+        required
+        type="number"
+        value={value}
+        min={1}
+        max={100}
+        onBlur={onBlur}
+        onChange={($e) => {
+          let yesThreshold = $e.target.value
+          if (yesThreshold.length) {
+            yesThreshold =
+              +yesThreshold < 1 ? 1 : +yesThreshold > 100 ? 100 : yesThreshold
+          }
+          onChange(+yesThreshold)
+        }}
+      />
+      <div className="pb-5" />
+      <AmountSlider
+        step={1}
+        value={value ?? 60}
+        disabled={false}
+        onChange={onChange}
+      />
+    </>
+  )
+}
+
+export default ApprovalQuorumInput

--- a/components/RealmWizard/components/Steps/BespokeConfig.tsx
+++ b/components/RealmWizard/components/Steps/BespokeConfig.tsx
@@ -1,12 +1,192 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
-import React from 'react'
+import React, { useEffect } from 'react'
 import { RealmWizardStepComponentProps } from '@components/RealmWizard/interfaces/Realm'
+import Input from '@components/inputs/Input'
+import {
+  formatMintNaturalAmountAsDecimal,
+  getMintDecimalAmount,
+} from '@tools/sdk/units'
+import { BN } from '@project-serum/anchor'
+import { tryGetMint } from '@utils/tokens'
+import { PublicKey } from '@solana/web3.js'
+import useWalletStore from 'stores/useWalletStore'
+import _ from 'lodash'
 
 const BespokeConfig: React.FC<RealmWizardStepComponentProps> = ({
   setForm,
   form,
+  formErrors,
+  setFormErrors,
+  beforeClickNext,
 }) => {
-  return <></>
+  const { connection } = useWalletStore((s) => s)
+
+  const handleCommunityMint = async (mintId: string) => {
+    try {
+      const mintPublicKey = new PublicKey(mintId)
+      const mint = await tryGetMint(connection.current, mintPublicKey)
+      if (mint) {
+        const supply = mint.account.supply
+        if (supply.gt(new BN(0))) {
+          setForm({
+            minCommunityTokensToCreateGovernance: BN.max(
+              new BN(1),
+              // divide by 100 for a percentage
+              new BN(
+                getMintDecimalAmount(mint.account, supply)
+                  .dividedBy(100)
+                  .toString()
+              )
+            ),
+            communityMint: mint,
+          })
+        } else {
+          setForm({
+            communityMint: mint,
+          })
+        }
+      }
+    } catch (e) {
+      console.log('failed to set community mint', e)
+    }
+  }
+
+  const handleCouncilMint = async (mintId: string) => {
+    try {
+      const mintPublicKey = new PublicKey(mintId)
+      const mint = await tryGetMint(connection.current, mintPublicKey)
+      if (mint) {
+        setForm({
+          councilMint: mint,
+        })
+      }
+    } catch (e) {
+      console.log('failed to set council mint', e)
+    }
+  }
+
+  useEffect(() => {
+    _.debounce(async () => {
+      if (form?.councilMintId) {
+        await handleCouncilMint(form.councilMintId)
+      }
+      if (form?.communityMintId) {
+        await handleCommunityMint(form.communityMintId)
+      }
+    }, 250)()
+  }, [form?.communityMintId, form?.councilMintId])
+
+  return (
+    <>
+      <div className="border-b border-fgd-4 pb-4 pt-2">
+        <div className="flex items-center justify-between">
+          <h1>Create a new realm</h1>
+        </div>
+      </div>
+      <div className="pt-2">
+        <div className="pb-4 pr-10 mr-2">
+          <Input
+            label="Name"
+            placeholder="Name of your realm"
+            value={form.name}
+            type="text"
+            error={formErrors['name']}
+            onChange={(evt) =>
+              setForm({
+                name: evt.target.value,
+              })
+            }
+          />
+        </div>
+        <div className="pb-4 pr-10 mr-2">
+          <Input
+            label="Community Mint Id"
+            placeholder="Community mint id of this realm"
+            value={form?.communityMintId}
+            type="text"
+            error={formErrors['communityMintId'] || formErrors['communityMint']}
+            onChange={(evt) => setForm({ communityMintId: evt.target.value })}
+          />
+          {form?.communityMint && (
+            <div className="pt-2">
+              <div className="pb-0.5 text-fgd-3 text-xs">Mint supply</div>
+              <div className="text-xs">
+                {formatMintNaturalAmountAsDecimal(
+                  form.communityMint.account,
+                  form.communityMint.account.supply
+                )}
+              </div>
+            </div>
+          )}
+        </div>
+        {form?.communityMint && (
+          <>
+            <div className="pb-4 pr-10 mr-2">
+              <Input
+                label="Min community tokens to create governance (defaults 1% of community mint)"
+                placeholder="Min community tokens to create governance"
+                step="0.01"
+                value={form.minCommunityTokensToCreateGovernance}
+                type="number"
+                error={formErrors['minCommunityTokensToCreateGovernance']}
+                onChange={(evt) =>
+                  setForm({
+                    minCommunityTokensToCreateGovernance: new BN(
+                      evt.target.value
+                    ),
+                  })
+                }
+              />
+            </div>
+            <div className="pb-4 pr-10 mr-2">
+              <Input
+                label="Community mint supply factor (max vote weight)"
+                placeholder="Community mint supply factor (max vote weight)"
+                value={form.communityMintMaxVoteWeightSource}
+                type="number"
+                error={formErrors['communityMintMaxVoteWeightSource']}
+                onChange={(evt) =>
+                  setForm({
+                    communityMintMaxVoteWeightSource: evt.target.value,
+                  })
+                }
+              />
+            </div>
+          </>
+        )}
+        <div className="pb-4 pr-10 mr-2">
+          <Input
+            label="Governance Program Id"
+            placeholder="Id of the governance program this realm will be associated with"
+            value={form?.governanceProgramId}
+            type="text"
+            error={formErrors['governanceProgramId']}
+            onChange={(evt) =>
+              setForm({
+                governanceProgramId: evt.target.value,
+              })
+            }
+          />
+        </div>
+        <div className="pb-4 pr-10 mr-2">
+          <Input
+            label="Governance program version"
+            placeholder={1}
+            step="1"
+            min={1}
+            value={form?.programVersion}
+            type="number"
+            error={formErrors['programVersion']}
+            onChange={(evt) =>
+              setForm({
+                programVersion: evt.target.value,
+              })
+            }
+          />
+        </div>
+      </div>
+    </>
+  )
 }
 
 export default BespokeConfig

--- a/components/RealmWizard/components/Steps/BespokeConfig.tsx
+++ b/components/RealmWizard/components/Steps/BespokeConfig.tsx
@@ -2,11 +2,11 @@
 import React from 'react'
 import { RealmWizardStepComponentProps } from '@components/RealmWizard/interfaces/Realm'
 
-const StepTwo: React.FC<RealmWizardStepComponentProps> = ({
+const BespokeConfig: React.FC<RealmWizardStepComponentProps> = ({
   setForm,
   form,
 }) => {
   return <></>
 }
 
-export default StepTwo
+export default BespokeConfig

--- a/components/RealmWizard/components/Steps/BespokeCouncil.tsx
+++ b/components/RealmWizard/components/Steps/BespokeCouncil.tsx
@@ -1,12 +1,32 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
 import React from 'react'
 import { RealmWizardStepComponentProps } from '@components/RealmWizard/interfaces/Realm'
+import Input from '@components/inputs/Input'
 
 const BespokeCouncil: React.FC<RealmWizardStepComponentProps> = ({
   setForm,
   form,
+  formErrors,
 }) => {
-  return <></>
+  return (
+    <>
+      <div className="border-b border-fgd-4 pb-4 pt-2">
+        <div className="flex items-center justify-between">
+          <h1>Council Settings</h1>
+        </div>
+      </div>
+      <div className="pb-4 pr-10 mr-2">
+        <Input
+          label="Council Mint Id"
+          placeholder="(Optional) Council mint"
+          value={form?.councilMintId}
+          type="text"
+          error={formErrors['councilMintId'] || formErrors['councilMint']}
+          onChange={(evt) => setForm({ councilMintId: evt.target.value })}
+        />
+      </div>
+    </>
+  )
 }
 
 export default BespokeCouncil

--- a/components/RealmWizard/components/Steps/BespokeCouncil.tsx
+++ b/components/RealmWizard/components/Steps/BespokeCouncil.tsx
@@ -2,11 +2,11 @@
 import React from 'react'
 import { RealmWizardStepComponentProps } from '@components/RealmWizard/interfaces/Realm'
 
-const StepThree: React.FC<RealmWizardStepComponentProps> = ({
+const BespokeCouncil: React.FC<RealmWizardStepComponentProps> = ({
   setForm,
   form,
 }) => {
   return <></>
 }
 
-export default StepThree
+export default BespokeCouncil

--- a/components/RealmWizard/components/Steps/BespokeCouncil.tsx
+++ b/components/RealmWizard/components/Steps/BespokeCouncil.tsx
@@ -33,13 +33,24 @@ const BespokeCouncil: React.FC<RealmWizardStepComponentProps> = ({
       setForm({ teamWallets })
     }
   }
-  useEffect(() => {
+
+  const handleWallets = () => {
     if (councilMintSwitch && wallet?.publicKey) {
+      // Forces to add the current wallet
       handleInsertTeamWallet([wallet.publicKey.toBase58()])
     } else {
       setForm({ teamWallets: [] })
     }
+  }
+
+  useEffect(() => {
+    handleWallets()
   }, [councilMintSwitch])
+
+  useEffect(() => {
+    handleWallets()
+  }, [])
+
   return (
     <>
       <div className="border-b border-fgd-4 pb-4 pt-2">
@@ -56,25 +67,25 @@ const BespokeCouncil: React.FC<RealmWizardStepComponentProps> = ({
           />
           <StyledLabel className="mt-1.5 ml-3">Use Council</StyledLabel>
         </div>
-        {councilMintSwitch && (
-          <>
-            <Input
-              label="Council Mint Id"
-              placeholder="(Optional) Council mint"
-              value={form?.councilMintId}
-              type="text"
-              error={formErrors['councilMintId'] || formErrors['councilMint']}
-              onChange={(evt) => setForm({ councilMintId: evt.target.value })}
-            />
-
-            <TeamWalletField
-              onInsert={handleInsertTeamWallet}
-              onRemove={handleRemoveTeamWallet}
-              wallets={form.teamWallets}
-            />
-          </>
-        )}
       </div>
+      {councilMintSwitch && (
+        <div className="w-full">
+          <Input
+            label="Council Mint Id"
+            placeholder="(Optional) Council mint"
+            value={form?.councilMintId}
+            type="text"
+            error={formErrors['councilMintId'] || formErrors['councilMint']}
+            onChange={(evt) => setForm({ councilMintId: evt.target.value })}
+          />
+
+          <TeamWalletField
+            onInsert={handleInsertTeamWallet}
+            onRemove={handleRemoveTeamWallet}
+            wallets={form.teamWallets}
+          />
+        </div>
+      )}
     </>
   )
 }

--- a/components/RealmWizard/components/Steps/BespokeCouncil.tsx
+++ b/components/RealmWizard/components/Steps/BespokeCouncil.tsx
@@ -1,13 +1,36 @@
 /* eslint-disable @typescript-eslint/no-unused-vars */
-import React from 'react'
+import React, { useState } from 'react'
 import { RealmWizardStepComponentProps } from '@components/RealmWizard/interfaces/Realm'
 import Input from '@components/inputs/Input'
-
+import Switch from '@components/Switch'
+import { StyledLabel } from '@components/inputs/styles'
+import TeamWalletField from '../TeamWalletField'
 const BespokeCouncil: React.FC<RealmWizardStepComponentProps> = ({
   setForm,
   form,
   formErrors,
 }) => {
+  const [councilMintSwitch, setCouncilMintSwitch] = useState(false)
+  const handleInsertTeamWallet = (wallets: string[]) => {
+    let teamWallets: string[] = []
+    if (form?.teamWallets) {
+      teamWallets = form.teamWallets
+    }
+    wallets.forEach((wallet) => {
+      if (!teamWallets.find((addr) => addr === wallet)) {
+        teamWallets.push(wallet)
+        setForm({ teamWallets })
+      }
+    })
+  }
+
+  const handleRemoveTeamWallet = (index: number) => {
+    if (form?.teamWallets && form.teamWallets[index]) {
+      const teamWallets = form.teamWallets
+      teamWallets.splice(index, 1)
+      setForm({ teamWallets })
+    }
+  }
   return (
     <>
       <div className="border-b border-fgd-4 pb-4 pt-2">
@@ -16,14 +39,32 @@ const BespokeCouncil: React.FC<RealmWizardStepComponentProps> = ({
         </div>
       </div>
       <div className="pb-4 pr-10 mr-2">
-        <Input
-          label="Council Mint Id"
-          placeholder="(Optional) Council mint"
-          value={form?.councilMintId}
-          type="text"
-          error={formErrors['councilMintId'] || formErrors['councilMint']}
-          onChange={(evt) => setForm({ councilMintId: evt.target.value })}
-        />
+        <div className="flex justify-left items-center">
+          <Switch
+            className="mt-2 mb-2"
+            checked={councilMintSwitch}
+            onChange={() => setCouncilMintSwitch(!councilMintSwitch)}
+          />
+          <StyledLabel className="mt-1.5 ml-3">Use Council</StyledLabel>
+        </div>
+        {councilMintSwitch && (
+          <>
+            <Input
+              label="Council Mint Id"
+              placeholder="(Optional) Council mint"
+              value={form?.councilMintId}
+              type="text"
+              error={formErrors['councilMintId'] || formErrors['councilMint']}
+              onChange={(evt) => setForm({ councilMintId: evt.target.value })}
+            />
+
+            <TeamWalletField
+              onInsert={handleInsertTeamWallet}
+              onRemove={handleRemoveTeamWallet}
+              wallets={form.teamWallets}
+            />
+          </>
+        )}
       </div>
     </>
   )

--- a/components/RealmWizard/components/Steps/BespokeCouncil.tsx
+++ b/components/RealmWizard/components/Steps/BespokeCouncil.tsx
@@ -6,6 +6,8 @@ import Switch from '@components/Switch'
 import { StyledLabel } from '@components/inputs/styles'
 import TeamWalletField from '../TeamWalletField'
 import useWalletStore from 'stores/useWalletStore'
+import ApprovalQuorumInput from '../ApprovalQuorumInput'
+
 const BespokeCouncil: React.FC<RealmWizardStepComponentProps> = ({
   setForm,
   form,
@@ -69,22 +71,42 @@ const BespokeCouncil: React.FC<RealmWizardStepComponentProps> = ({
         </div>
       </div>
       {councilMintSwitch && (
-        <div className="w-full">
-          <Input
-            label="Council Mint Id"
-            placeholder="(Optional) Council mint"
-            value={form?.councilMintId}
-            type="text"
-            error={formErrors['councilMintId'] || formErrors['councilMint']}
-            onChange={(evt) => setForm({ councilMintId: evt.target.value })}
-          />
+        <>
+          <div className="pb-7 pr-10 w-full">
+            <Input
+              label="Council Mint Id"
+              placeholder="(Optional) Council mint"
+              value={form?.councilMintId}
+              type="text"
+              error={formErrors['councilMintId'] || formErrors['councilMint']}
+              onChange={(evt) => setForm({ councilMintId: evt.target.value })}
+            />
+          </div>
+          <div className="pb-7 pr-10 w-full" style={{ maxWidth: 512 }}>
+            <ApprovalQuorumInput
+              value={form.yesThreshold}
+              onChange={($e) => {
+                setForm({ yesThreshold: $e })
+              }}
+              onBlur={() => {
+                if (
+                  !form.yesThreshold ||
+                  form.yesThreshold.toString().match(/\D+/gim)
+                ) {
+                  setForm({
+                    yesThreshold: 60,
+                  })
+                }
+              }}
+            />
+          </div>
 
           <TeamWalletField
             onInsert={handleInsertTeamWallet}
             onRemove={handleRemoveTeamWallet}
             wallets={form.teamWallets}
           />
-        </div>
+        </>
       )}
     </>
   )

--- a/components/RealmWizard/components/Steps/MultisigOptions.tsx
+++ b/components/RealmWizard/components/Steps/MultisigOptions.tsx
@@ -3,8 +3,8 @@ import { RealmWizardStepComponentProps } from '../../interfaces/Realm'
 import TeamWalletField from '../TeamWalletField'
 import Input from '@components/inputs/Input'
 import { StyledLabel } from '@components/inputs/styles'
-import AmountSlider from '@components/Slider'
 import useWalletStore from 'stores/useWalletStore'
+import ApprovalQuorumInput from '../ApprovalQuorumInput'
 
 /**
  * This is the Step One for the Realm Wizard.
@@ -71,13 +71,11 @@ const MultisigOptions: React.FC<RealmWizardStepComponentProps> = ({
         />
       </div>
       <div className="pb-7 pr-10 w-full" style={{ maxWidth: 512 }}>
-        <StyledLabel>Approval quorum (%)</StyledLabel>
-        <Input
-          required
-          type="number"
+        <ApprovalQuorumInput
           value={form.yesThreshold}
-          min={1}
-          max={100}
+          onChange={($e) => {
+            setForm({ yesThreshold: $e })
+          }}
           onBlur={() => {
             if (
               !form.yesThreshold ||
@@ -88,38 +86,7 @@ const MultisigOptions: React.FC<RealmWizardStepComponentProps> = ({
               })
             }
           }}
-          onChange={($e) => {
-            let yesThreshold = $e.target.value
-            if (yesThreshold.length) {
-              yesThreshold =
-                +yesThreshold < 1 ? 1 : +yesThreshold > 100 ? 100 : yesThreshold
-            }
-            setForm({
-              yesThreshold,
-            })
-          }}
         />
-        <div className="pb-5" />
-        <AmountSlider
-          step={1}
-          value={form.yesThreshold ?? DEFAULT_APPROVAL_QUORUM}
-          disabled={false}
-          onChange={($e) => {
-            setForm({ yesThreshold: $e })
-          }}
-        />
-        {/* <Input
-          required
-          type="number"
-          value={form.yesThreshold}
-          placeholder="Vote threshold"
-          onChange={($e) => {
-            if (+$e.target.value > 0 && +$e.target.value <= 100)
-              setForm({
-                yesThreshold: $e.target.value,
-              })
-          }}
-        /> */}
       </div>
       <div className="pb-4">
         <TeamWalletField

--- a/components/RealmWizard/components/Steps/MultisigOptions.tsx
+++ b/components/RealmWizard/components/Steps/MultisigOptions.tsx
@@ -13,7 +13,7 @@ import AmountSlider from '@components/Slider'
  *
  * @param param0 the form data and form handler.
  */
-const StepOne: React.FC<RealmWizardStepComponentProps> = ({
+const MultisigOptions: React.FC<RealmWizardStepComponentProps> = ({
   setForm,
   form,
 }) => {
@@ -122,4 +122,4 @@ const StepOne: React.FC<RealmWizardStepComponentProps> = ({
   )
 }
 
-export default StepOne
+export default MultisigOptions

--- a/components/RealmWizard/components/Steps/index.tsx
+++ b/components/RealmWizard/components/Steps/index.tsx
@@ -1,8 +1,15 @@
-import StepOne from './StepOne'
-import StepTwo from './StepTwo'
-import StepThree from './StepThree'
+import MultisigOptions from './MultisigOptions'
+import BespokeConfig from './BespokeConfig'
+import BespokeCouncil from './BespokeCouncil'
 import StepFour from './StepFour'
 import WizardModeSelect from './WizardModeSelect'
 import RealmCreated from './RealmCreated'
 
-export { StepOne, StepTwo, StepThree, StepFour, WizardModeSelect, RealmCreated }
+export {
+  MultisigOptions,
+  BespokeConfig,
+  BespokeCouncil,
+  StepFour,
+  WizardModeSelect,
+  RealmCreated,
+}

--- a/components/RealmWizard/components/TeamWalletField.tsx
+++ b/components/RealmWizard/components/TeamWalletField.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react'
+import React, { useEffect, useState } from 'react'
 import { StyledLabel } from '@components/inputs/styles'
 import AddWalletModal from './AddWalletModal'
 import { TrashIcon } from '@heroicons/react/solid'
@@ -47,6 +47,15 @@ const TeamWalletField: React.FC<{
       />
     )
   }
+
+  useEffect(() => {
+    if (
+      wallet?.publicKey &&
+      !wallets.find((addr) => addr === wallet.publicKey?.toBase58())
+    ) {
+      onInsert([wallet.publicKey?.toBase58()])
+    }
+  }, [wallets.length, wallet?.publicKey])
 
   return (
     <div className="team-wallets-wrapper">

--- a/components/RealmWizard/controller/RealmWizardController.ts
+++ b/components/RealmWizard/controller/RealmWizardController.ts
@@ -36,10 +36,11 @@ class RealmWizardController {
     this.steps.push(RealmWizardStep.SELECT_MODE)
     switch (this.mode) {
       case RealmWizardMode.BASIC:
-        this.steps.push(RealmWizardStep.BASIC_CONFIG)
+        this.steps.push(RealmWizardStep.MULTISIG_CONFIG)
         break
       case RealmWizardMode.ADVANCED:
-        this.steps.push(RealmWizardStep.TOKENS_CONFIG)
+        this.steps.push(RealmWizardStep.BESPOKE_CONFIG)
+        this.steps.push(RealmWizardStep.BESPOKE_COUNCIL)
         break
       default:
         throw new Error('The selected mode is not available')
@@ -88,6 +89,15 @@ class RealmWizardController {
    */
   getCurrentStep(): RealmWizardStep {
     return this.currentStep
+  }
+
+  /**
+   * Returns the pagination position of the current step
+   */
+  getStepPagination(): string {
+    const currentStepIdx = this.steps.indexOf(this.currentStep) + 1
+    const pages = this.steps.length
+    return `Step ${currentStepIdx} of ${pages}`
   }
 
   /**

--- a/components/RealmWizard/interfaces/Realm.ts
+++ b/components/RealmWizard/interfaces/Realm.ts
@@ -2,6 +2,7 @@ import { ProgramVersion } from '@models/registry/constants'
 import { BN, ProgramAccount } from '@project-serum/anchor'
 import { MintInfo } from '@solana/spl-token'
 import { PublicKey } from '@solana/web3.js'
+import React from 'react'
 
 /**
  * Default realm artifact interface
@@ -76,6 +77,7 @@ export enum StepDirection {
 export interface RealmWizardStepComponentProps {
   form: RealmArtifacts
   setForm: (data: RealmArtifacts) => void
+  beforeClickNext?: React.Dispatch<(...args) => boolean>
   [key: string]: any
 }
 

--- a/components/RealmWizard/interfaces/Realm.ts
+++ b/components/RealmWizard/interfaces/Realm.ts
@@ -49,15 +49,15 @@ export enum RealmWizardStep {
   /**
    * Base state: set the name of the Realm and add the team wallets
    */
-  BASIC_CONFIG,
+  MULTISIG_CONFIG,
   /**
-   * Advanced config: set the token mints and governance program id
+   * Set up bespoke basic options
    */
-  TOKENS_CONFIG,
+  BESPOKE_CONFIG,
   /**
-   * Not defined yet
+   * Set up the Bespoke council options
    */
-  STEP_3,
+  BESPOKE_COUNCIL,
   /**
    * Not defined yet
    */

--- a/tools/sdk/splToken/withCreateMint.ts
+++ b/tools/sdk/splToken/withCreateMint.ts
@@ -23,6 +23,7 @@ export const withCreateMint = async (
   )
 
   const mintAccount = new Keypair()
+
   instructions.push(
     SystemProgram.createAccount({
       fromPubkey: payerPk,
@@ -43,6 +44,5 @@ export const withCreateMint = async (
       freezeAuthorityPk
     )
   )
-
   return mintAccount.publicKey
 }

--- a/utils/formValidation.tsx
+++ b/utils/formValidation.tsx
@@ -7,7 +7,7 @@ export interface formValidation {
 
 export const isFormValid = async (schema, formValues, abortEarly = false) => {
   if (!schema) {
-    throw 'pleas provide schema'
+    throw 'please provide schema'
   }
   const values = new SanitizedObject({
     isValid: false,


### PR DESCRIPTION
### Changelog

 - [X] Split the Bespoke realm form in two steps
 - [X] Refactored `ApprovalQuorumInput` into a component
 - [X] Changed `registerRealm` function to fit the new model
 - [X] Changed the steps component file names, interfaces and enums
 - [X] Created a switch state in RealmWizard to call the right create realm method
