### PR TITLE
Hotfix/wrong council mint amount

### DIFF
--- a/actions/registerRealm.ts
+++ b/actions/registerRealm.ts
@@ -42,12 +42,6 @@ import { ConnectionContext } from '@utils/connection'
 import { MIN_COMMUNITY_TOKENS_TO_CREATE_W_0_SUPPLY } from '@tools/constants'
 import BigNumber from 'bignumber.js'
 
-/* 
-  TODO: Check if the abstractions present here can be moved to a 
-  separate util and replace some of the repeating code over the project
-  and reduce the code complexity
-*/
-
 interface RegisterRealmRpc {
   connection: ConnectionContext
   wallet: SignerWalletAdapter
@@ -142,7 +136,6 @@ async function prepareMintInstructions(
   }
 
   const instructionChunks = chunks(mintInstructions, 10)
-  // I tried to left as an empty array, but always get failed in signature verification
   const signersChunks = Array(instructionChunks.length).fill([])
   signersChunks[0] = mintSigners
   return {

--- a/components/RealmWizard/RealmWizard.tsx
+++ b/components/RealmWizard/RealmWizard.tsx
@@ -188,6 +188,7 @@ const RealmWizard: React.FC = () => {
           form.yesThreshold,
           form.communityMintId ? form.transferAuthority : true,
           form.communityMint ? form.communityMint.account.decimals : undefined,
+          form.councilMint ? form.councilMint.account.decimals : undefined,
           getTeamWallets()
         )
         router.push(fmtUrlWithCluster(`/dao/${realmAddress.toBase58()}`))


### PR DESCRIPTION
### Changelog

 - [X] Fixed mint council tokens with hardcoded amount.
 - [X] Updated code documentation

> Solution: set `amount` as `u64(BN(1).shiftedBy(tokenDecimals))` so when mint has N decimals, it should mint `1 * (1eN)` instead of `1/1eN` that turns into a natural amount of 1