### PR TITLE
add new inputs styles for new mango ui design

### DIFF
--- a/components/Members/AddMember.tsx
+++ b/components/Members/AddMember.tsx
@@ -18,10 +18,12 @@ import { getMintSchema } from 'utils/validations'
 import { useEffect, useState } from 'react'
 import { MintForm, UiInstruction } from 'utils/uiTypes/proposalCreationTypes'
 import useGovernanceAssets from 'hooks/useGovernanceAssets'
-import { getInstructionDataFromBase64 } from '@solana/spl-governance'
-import { RpcContext } from '@solana/spl-governance'
-import { Governance } from '@solana/spl-governance'
-import { ProgramAccount } from '@solana/spl-governance'
+import {
+  getInstructionDataFromBase64,
+  RpcContext,
+  Governance,
+  ProgramAccount,
+} from '@solana/spl-governance'
 import { useRouter } from 'next/router'
 import { createProposal } from 'actions/createProposal'
 import { notify } from 'utils/notifications'
@@ -207,7 +209,7 @@ const AddMember = () => {
         <>
           <ArrowLeftIcon
             onClick={handleGoBackToMainView}
-            className="h-4 w-4 mr-1 text-primary-light mr-2"
+            className="h-4 w-4 text-primary-light mr-2"
           />
           Add new member
         </>

--- a/components/inputs/Input.tsx
+++ b/components/inputs/Input.tsx
@@ -1,5 +1,6 @@
 import { StyledLabel, StyledSuffix, inputClasses } from './styles'
 import ErrorField from './ErrorField'
+import { CheckCircleIcon } from '@heroicons/react/outline'
 
 interface InputProps {
   type: string
@@ -7,10 +8,13 @@ interface InputProps {
   onChange?: (e) => void
   className?: string
   disabled?: boolean
+  useDefaultStyle?: boolean
   [x: string]: any
+  checkIcon?: boolean
 }
 
 const Input = ({
+  checkIcon = false,
   type,
   value = '',
   onChange,
@@ -24,6 +28,7 @@ const Input = ({
   max = Number.MAX_SAFE_INTEGER,
   step,
   noMaxWidth,
+  useDefaultStyle = true,
   subtitle,
   ...props
 }: InputProps) => {
@@ -37,12 +42,24 @@ const Input = ({
         type={type}
         value={value}
         onChange={onChange}
-        className={inputClasses({ className, disabled, error, noMaxWidth })}
+        className={inputClasses({
+          className,
+          disabled,
+          error,
+          noMaxWidth,
+          useDefaultStyle,
+        })}
         disabled={disabled}
         step={step}
         {...props}
       />
+
+      {checkIcon && !error && (
+        <CheckCircleIcon className="w-6 h-6 absolute right-2 top-1/2 text-green" />
+      )}
+
       {suffix && <StyledSuffix>{suffix}</StyledSuffix>}
+
       <div className={error && 'pt-1'}>
         <ErrorField text={error}></ErrorField>
       </div>

--- a/components/inputs/Select.tsx
+++ b/components/inputs/Select.tsx
@@ -13,6 +13,7 @@ const Select = ({
   disabled = false,
   label = '',
   componentLabel,
+  useDefaultStyle = true,
   noMaxWidth = false,
 }: {
   value: any | undefined
@@ -24,17 +25,24 @@ const Select = ({
   disabled?: boolean | undefined
   label?: string | undefined
   componentLabel?: any | undefined
-  noMaxWidth?: boolean | undefined
+  useDefaultStyle?: boolean
+  noMaxWidth?: boolean
 }) => {
   return (
-    <div>
+    <div className="mt-6">
       {label && <StyledLabel>{label}</StyledLabel>}
       <div className={`relative ${className} ${error && 'pb-1'}`}>
         <Listbox value={value} onChange={onChange} disabled={disabled}>
           {({ open }) => (
             <>
               <Listbox.Button
-                className={inputClasses({ className, disabled, error })}
+                className={inputClasses({
+                  className,
+                  disabled,
+                  error,
+                  useDefaultStyle,
+                  noMaxWidth,
+                })}
               >
                 <div
                   className={`flex items-center justify-between text-fgd-1 text-left`}
@@ -68,8 +76,8 @@ const Select = ({
             </>
           )}
         </Listbox>
+        <ErrorField text={error}></ErrorField>
       </div>
-      <ErrorField text={error}></ErrorField>
     </div>
   )
 }

--- a/components/inputs/Textarea.tsx
+++ b/components/inputs/Textarea.tsx
@@ -6,6 +6,7 @@ interface TextareaProps {
   onChange?: (e) => void
   className?: string
   disabled?: boolean
+  useDefaultStyle?: boolean
   [x: string]: any
 }
 
@@ -19,19 +20,29 @@ const TextareaProps = ({
   suffix,
   error = '',
   noMaxWidth = false,
+  useDefaultStyle = true,
   ...props
 }: TextareaProps) => {
   return (
     <div className={`flex-col relative ${wrapperClassName}`}>
       {label && <StyledLabel>{label}</StyledLabel>}
+
       <textarea
         value={value}
         onChange={onChange}
-        className={inputClasses({ className, disabled, error, noMaxWidth })}
+        className={inputClasses({
+          className,
+          disabled,
+          error,
+          noMaxWidth,
+          useDefaultStyle,
+        })}
         disabled={disabled}
         {...props}
       />
+
       {suffix ? <StyledSuffix>{suffix}</StyledSuffix> : null}
+
       <ErrorField text={error}></ErrorField>
     </div>
   )

--- a/components/inputs/styles.tsx
+++ b/components/inputs/styles.tsx
@@ -15,13 +15,13 @@ export const inputClasses = ({
   useDefaultStyle = true,
 }) => {
   const disabledStyle =
-    'cursor-pointer opacity-60 text-fgd-3 hover:border-fgd-3 border border-bkg-4'
+    'cursor-not-allowed opacity-50 text-fgd-3 border bg-bkg-1 border-bkg-1'
 
   const defaultStyle = `${
     disabled
       ? disabledStyle
-      : 'p-3 w-full border border-fgd-3 default-transition text-sm text-fgd-1 rounded-md hover:border-primary-light focus:border-primary-light focus:outline-none bg-bkg-1'
-  }`
+      : 'hover:border-primary-light focus:border-primary-light focus:outline-none bg-bkg-1'
+  } p-3 w-full border border-fgd-3 default-transition text-sm text-fgd-1 rounded-md`
 
   return `
     ${

--- a/components/inputs/styles.tsx
+++ b/components/inputs/styles.tsx
@@ -8,22 +8,28 @@ export const StyledSuffix = styled.div`
   ${tw`absolute right-0 text-xs flex items-center pr-2 h-full bg-transparent text-fgd-4`}
 `
 export const inputClasses = ({
-  className,
+  className = '',
   disabled,
   error,
   noMaxWidth = false,
+  useDefaultStyle = true,
 }) => {
-  return `${
-    className ? className : ''
-  } p-3 w-full bg-bkg-1 rounded-md text-sm text-fgd-1 
-	border border-fgd-3 default-transition ${
-    !noMaxWidth ? 'max-w-lg' : ''
-  } hover:border-primary-light 
-	focus:border-primary-light focus:outline-none 
-	${error ? 'border-red' : 'border-fgd-4'}
-	${
+  const disabledStyle =
+    'cursor-pointer opacity-60 text-fgd-3 hover:border-fgd-3 border border-bkg-4'
+
+  const defaultStyle = `${
     disabled
-      ? 'cursor-not-allowed opacity-60 text-fgd-3 hover:border-fgd-3'
-      : ''
+      ? disabledStyle
+      : 'p-3 w-full border border-fgd-3 default-transition text-sm text-fgd-1 rounded-md hover:border-primary-light focus:border-primary-light focus:outline-none bg-bkg-1'
   }`
+
+  return `
+    ${
+      useDefaultStyle
+        ? defaultStyle
+        : `${disabled && disabledStyle} ${className}`
+    }
+    ${!noMaxWidth && 'max-w-lg'}
+    ${error ? 'border-red' : 'border-fgd-4'}
+  `
 }


### PR DESCRIPTION
- [x] add options to use default style (old input style) or use some custom style according to new figma mango ui design
- [x] refactor and separate disabled style to not nest ternaries