### PR TITLE
Convert SOL treasury to mSOL

### DIFF
--- a/components/TreasuryAccount/AccountOverview.tsx
+++ b/components/TreasuryAccount/AccountOverview.tsx
@@ -18,6 +18,7 @@ import DepositNFT from './DepositNFT'
 import { ViewState } from './Types'
 import SendTokens from './SendTokens'
 import { ExternalLinkIcon, ArrowsExpandIcon } from '@heroicons/react/outline'
+import Tooltip from '@components/Tooltip'
 
 const AccountOverview = () => {
   const router = useRouter()
@@ -33,6 +34,7 @@ const AccountOverview = () => {
   const { symbol } = useRealm()
   const { fmtUrlWithCluster } = useQueryContext()
   const isNFT = currentAccount?.isNft
+  const isSOL = currentAccount?.isSol
   const { canUseTransferInstruction } = useGovernanceAssets()
   const connection = useWalletStore((s) => s.connection)
   const recentActivity = useTreasuryAccountStore(
@@ -130,6 +132,22 @@ const AccountOverview = () => {
           disabled={!canUseTransferInstruction || (isNFT && nftsCount === 0)}
         >
           Send
+        </Button>
+      </div>
+      <div className="mb-4 flex flex-col">
+        <Button
+          className={`sm:w-full text-sm ${!isSOL ? 'hidden' : ''}`}
+          onClick={() => {}}
+          disabled={!canUseTransferInstruction}
+        >
+          <Tooltip
+            content={
+              !canUseTransferInstruction &&
+              'You need to be connected to your wallet to have the ability to create a token staking proposal'
+            }
+          >
+            <div>Convert to mSOL</div>
+          </Tooltip>
         </Button>
       </div>
       <div className="font-normal mr-1 text-xs text-fgd-3 mb-4">

--- a/components/TreasuryAccount/AccountOverview.tsx
+++ b/components/TreasuryAccount/AccountOverview.tsx
@@ -19,6 +19,7 @@ import { ViewState } from './Types'
 import SendTokens from './SendTokens'
 import { ExternalLinkIcon, ArrowsExpandIcon } from '@heroicons/react/outline'
 import Tooltip from '@components/Tooltip'
+import ConvertToMsol from './ConvertToMsol'
 
 const AccountOverview = () => {
   const router = useRouter()
@@ -42,6 +43,7 @@ const AccountOverview = () => {
   )
   const [openNftDepositModal, setOpenNftDepositModal] = useState(false)
   const [openCommonSendModal, setOpenCommonSendModal] = useState(false)
+  const [openMsolConvertModal, setOpenMsolConvertModal] = useState(false)
   const {
     setCurrentCompactView,
     resetCompactViewState,
@@ -137,7 +139,7 @@ const AccountOverview = () => {
       <div className="mb-4 flex flex-col">
         <Button
           className={`sm:w-full text-sm ${!isSOL ? 'hidden' : ''}`}
-          onClick={() => {}}
+          onClick={() => setOpenMsolConvertModal(true)}
           disabled={!canUseTransferInstruction}
         >
           <Tooltip
@@ -199,6 +201,17 @@ const AccountOverview = () => {
           isOpen={openCommonSendModal}
         >
           <SendTokens></SendTokens>
+        </Modal>
+      )}
+      {openMsolConvertModal && (
+        <Modal
+          sizeClassName="sm:max-w-3xl"
+          onClose={() => {
+            setOpenMsolConvertModal(false)
+          }}
+          isOpen={openMsolConvertModal}
+        >
+          <ConvertToMsol></ConvertToMsol>
         </Modal>
       )}
     </>

--- a/components/TreasuryAccount/ConvertToMsol.tsx
+++ b/components/TreasuryAccount/ConvertToMsol.tsx
@@ -26,7 +26,6 @@ import {
   Governance,
   ProgramAccount,
   RpcContext,
-  serializeInstructionToBase64,
 } from '@solana/spl-governance'
 import { getProgramVersionForRealm } from '@models/registry/api'
 import { createProposal } from 'actions/createProposal'

--- a/components/TreasuryAccount/ConvertToMsol.tsx
+++ b/components/TreasuryAccount/ConvertToMsol.tsx
@@ -1,0 +1,194 @@
+import { ArrowCircleDownIcon, ArrowCircleUpIcon } from '@heroicons/react/solid'
+import useTreasuryAccountStore from 'stores/useTreasuryAccountStore'
+import { ViewState } from './Types'
+import AccountLabel from './AccountHeader'
+import GovernedAccountSelect from 'pages/dao/[symbol]/proposal/components/GovernedAccountSelect'
+import useGovernanceAssets from '@hooks/useGovernanceAssets'
+import { GovernedMultiTypeAccount } from '@utils/tokens'
+import { useEffect, useState } from 'react'
+import { StakingViewForm } from '@utils/uiTypes/proposalCreationTypes'
+import { getMintMinAmountAsDecimal } from '@tools/sdk/units'
+import Input from '@components/inputs/Input'
+import Textarea from '@components/inputs/Textarea'
+import { precision } from '@utils/formatting'
+import useRealm from '@hooks/useRealm'
+import VoteBySwitch from 'pages/dao/[symbol]/proposal/components/VoteBySwitch'
+import Button, { SecondaryButton } from '@components/Button'
+import Tooltip from '@components/Tooltip'
+
+const ConvertToMsol = () => {
+  const { canChooseWhoVote } = useRealm()
+  const { canUseTransferInstruction } = useGovernanceAssets()
+  const {
+    setCurrentCompactView,
+    resetCompactViewState,
+  } = useTreasuryAccountStore()
+  const { governedTokenAccounts } = useGovernanceAssets()
+  const currentAccount = useTreasuryAccountStore(
+    (s) => s.compact.currentAccount
+  )
+  const notConnectedMessage =
+    'You need to be connected to your wallet to have the ability to create a token staking proposal'
+
+  const [formErrors, setFormErrors] = useState({})
+  const [form, setForm] = useState<StakingViewForm>({
+    destinationAccount: '',
+    amount: undefined,
+    governedTokenAccount: undefined,
+    title: '',
+    description: '',
+  })
+  const [showOptions, setShowOptions] = useState(false)
+  const [voteByCouncil, setVoteByCouncil] = useState(false)
+  const [isLoading, setIsLoading] = useState(false)
+
+  const mSolTokenAccounts = governedTokenAccounts.filter(
+    (acc) =>
+      acc.mint?.publicKey.toString() ===
+      'mSoLzYCxHdYgdzU16g5QSh3i5K3z3KZK7ytfqcJm7So'
+  )
+  const mintMinAmount = form.governedTokenAccount?.mint
+    ? getMintMinAmountAsDecimal(form.governedTokenAccount.mint.account)
+    : 1
+
+  const handleSetForm = ({ propertyName, value }) => {
+    setFormErrors({})
+    setForm({ ...form, [propertyName]: value })
+  }
+
+  const handleGoBackToMainView = () => {
+    setCurrentCompactView(ViewState.MainView)
+    resetCompactViewState()
+  }
+
+  const handlePropose = () => {
+    setIsLoading(true)
+    // ToDo: Initiate proposal creation
+    setIsLoading(false)
+  }
+
+  useEffect(() => {
+    handleSetForm({
+      value: currentAccount,
+      propertyName: 'governedTokenAccount',
+    })
+  }, [currentAccount])
+
+  return (
+    <>
+      <h3 className="mb-4 flex items-center">Convert SOL to mSOL</h3>
+      <AccountLabel></AccountLabel>
+      <div className="space-y-4 w-full pb-4">
+        <GovernedAccountSelect
+          label="mSOL Treasury account"
+          governedAccounts={mSolTokenAccounts as GovernedMultiTypeAccount[]}
+          shouldBeGoverned={false}
+          governance={currentAccount?.governance}
+          value={form.destinationAccount}
+          onChange={(evt) =>
+            handleSetForm({
+              value: evt,
+              propertyName: 'destinationAccount',
+            })
+          }
+          error={formErrors['destinationAccount']}
+        ></GovernedAccountSelect>
+        <Input
+          min={mintMinAmount}
+          label="Amount SOL"
+          type="number"
+          value={form.amount}
+          step={mintMinAmount}
+          onChange={(evt) =>
+            handleSetForm({
+              value: evt.target.value,
+              propertyName: 'amount',
+            })
+          }
+          onBlur={(evt) =>
+            handleSetForm({
+              value: parseFloat(
+                Math.max(
+                  Number(mintMinAmount),
+                  Math.min(
+                    Number(Number.MAX_SAFE_INTEGER),
+                    Number(evt.target.value)
+                  )
+                ).toFixed(precision(mintMinAmount))
+              ),
+              propertyName: 'amount',
+            })
+          }
+          error={formErrors['amount']}
+          noMaxWidth={true}
+        />
+        <div
+          className="flex items-center hover:cursor-pointer w-24"
+          onClick={() => setShowOptions(!showOptions)}
+        >
+          <div className="h-4 w-4 mr-1 text-primary-light">
+            {showOptions ? <ArrowCircleUpIcon /> : <ArrowCircleDownIcon />}
+          </div>
+          <small className="text-fgd-3">Options</small>
+        </div>
+        {showOptions && (
+          <>
+            <Input
+              noMaxWidth={true}
+              label="Title"
+              value={form.title}
+              type="text"
+              placeholder={
+                form.amount && form.destinationAccount
+                  ? `Convert ${form.amount} SOL to mSOL`
+                  : 'Title of your proposal'
+              }
+              onChange={(evt) =>
+                handleSetForm({
+                  value: evt.target.value,
+                  propertyName: 'title',
+                })
+              }
+            />
+            <Textarea
+              noMaxWidth={true}
+              label="Description"
+              placeholder={
+                'Description of your proposal or use a github gist link (optional)'
+              }
+              wrapperClassName="mb-5"
+              value={form.description}
+              onChange={(evt) =>
+                handleSetForm({
+                  value: evt.target.value,
+                  propertyName: 'description',
+                })
+              }
+            ></Textarea>
+            {canChooseWhoVote && (
+              <VoteBySwitch
+                checked={voteByCouncil}
+                onChange={() => {
+                  setVoteByCouncil(!voteByCouncil)
+                }}
+              ></VoteBySwitch>
+            )}
+          </>
+        )}
+      </div>
+      <div className="flex flex-col sm:flex-row sm:space-x-4 space-y-4 sm:space-y-0 mt-4">
+        <Button
+          className="ml-auto"
+          disabled={!canUseTransferInstruction || isLoading}
+          onClick={handlePropose}
+        >
+          <Tooltip content={!canUseTransferInstruction && notConnectedMessage}>
+            Propose
+          </Tooltip>
+        </Button>
+      </div>
+    </>
+  )
+}
+
+export default ConvertToMsol

--- a/components/TreasuryAccount/ConvertToMsol.tsx
+++ b/components/TreasuryAccount/ConvertToMsol.tsx
@@ -79,6 +79,7 @@ const ConvertToMsol = () => {
   const mintMinAmount = form.governedTokenAccount?.mint
     ? getMintMinAmountAsDecimal(form.governedTokenAccount.mint.account)
     : 1
+  const proposalTitle = `Convert ${form.amount} SOL to mSOL`
   const schema = getStakeSchema({ form })
 
   const handleSetForm = ({ propertyName, value }) => {
@@ -151,7 +152,7 @@ const ConvertToMsol = () => {
           realm,
           selectedGovernance.pubkey,
           ownTokenRecord.pubkey,
-          form.title ? form.title : '',
+          form.title ? form.title : proposalTitle,
           form.description ? form.description : '',
           proposalMint,
           selectedGovernance?.account?.proposalCount,
@@ -244,7 +245,7 @@ const ConvertToMsol = () => {
               type="text"
               placeholder={
                 form.amount && form.destinationAccount
-                  ? `Convert ${form.amount} SOL to mSOL`
+                  ? proposalTitle
                   : 'Title of your proposal'
               }
               onChange={(evt) =>

--- a/components/TreasuryAccount/ConvertToMsol.tsx
+++ b/components/TreasuryAccount/ConvertToMsol.tsx
@@ -77,13 +77,11 @@ const ConvertToMsol = () => {
   }
 
   useEffect(() => {
-    if (currentAccount) {
-      handleSetForm({
-        value: currentAccount,
-        propertyName: 'governedTokenAccount',
-      })
-    }
-  }, [currentAccount, form.destinationAccount]) // GovernedAccountSelect overrides property for one item
+    handleSetForm({
+      value: currentAccount,
+      propertyName: 'governedTokenAccount',
+    })
+  }, [currentAccount])
 
   return (
     <>

--- a/components/TreasuryAccount/ConvertToMsol.tsx
+++ b/components/TreasuryAccount/ConvertToMsol.tsx
@@ -101,6 +101,7 @@ const ConvertToMsol = () => {
             })
           }
           error={formErrors['destinationAccount']}
+          noMaxWidth={true}
         ></GovernedAccountSelect>
         <Input
           min={mintMinAmount}

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "@emotion/styled": "^11.3.0",
     "@headlessui/react": "^1.4.2",
     "@heroicons/react": "^1.0.1",
+    "@marinade.finance/marinade-ts-sdk": "^2.0.9",
     "@metaplex/js": "^4.10.1",
     "@nfteyez/sol-rayz": "^0.8.0",
     "@project-serum/anchor": "^0.10.0",

--- a/pages/dao/[symbol]/proposal/components/GovernedAccountSelect.tsx
+++ b/pages/dao/[symbol]/proposal/components/GovernedAccountSelect.tsx
@@ -18,6 +18,7 @@ const GovernedAccountSelect = ({
   shouldBeGoverned,
   governance,
   label,
+  noMaxWidth,
 }: {
   onChange
   value
@@ -26,6 +27,7 @@ const GovernedAccountSelect = ({
   shouldBeGoverned?
   governance?: ProgramAccount<Governance> | null | undefined
   label?
+  noMaxWidth?: boolean
 }) => {
   function getLabel(value: GovernedMultiTypeAccount) {
     if (value) {
@@ -123,6 +125,7 @@ const GovernedAccountSelect = ({
       placeholder="Please select..."
       value={value?.governance?.account.governedAccount.toBase58()}
       error={error}
+      noMaxWidth={noMaxWidth}
     >
       {governedAccounts
         .filter((x) =>

--- a/utils/instructionTools.ts
+++ b/utils/instructionTools.ts
@@ -5,7 +5,7 @@ import {
   TOKEN_PROGRAM_ID,
   u64,
 } from '@solana/spl-token'
-import { SignerWalletAdapter, WalletAdapter } from '@solana/wallet-adapter-base'
+import { WalletAdapter } from '@solana/wallet-adapter-base'
 import {
   PublicKey,
   SystemProgram,

--- a/utils/instructionTools.ts
+++ b/utils/instructionTools.ts
@@ -5,7 +5,7 @@ import {
   TOKEN_PROGRAM_ID,
   u64,
 } from '@solana/spl-token'
-import { WalletAdapter } from '@solana/wallet-adapter-base'
+import { SignerWalletAdapter, WalletAdapter } from '@solana/wallet-adapter-base'
 import {
   PublicKey,
   SystemProgram,
@@ -314,5 +314,32 @@ export async function getMintInstruction({
     governance: governedMintInfoAccount?.governance,
     prerequisiteInstructions: prerequisiteInstructions,
   }
+  return obj
+}
+
+export async function getConvertToMsolInstruction({
+  schema,
+  form,
+  connection,
+  wallet,
+  setFormErrors,
+}: {
+  schema: any
+  form: any
+  connection: ConnectionContext
+  wallet: SignerWalletAdapter | undefined
+  setFormErrors: any
+}): Promise<UiInstruction> {
+  const isValid = await validateInstruction({ schema, form, setFormErrors })
+  const prerequisiteInstructions: TransactionInstruction[] = []
+  const serializedInstruction: string = ''
+
+  const obj: UiInstruction = {
+    serializedInstruction,
+    isValid,
+    governance: form.governedTokenAccount?.governance,
+    prerequisiteInstructions: prerequisiteInstructions,
+  }
+
   return obj
 }

--- a/utils/instructionTools.ts
+++ b/utils/instructionTools.ts
@@ -335,7 +335,7 @@ export async function getConvertToMsolInstruction({
 }): Promise<UiInstruction> {
   const isValid = await validateInstruction({ schema, form, setFormErrors })
   const prerequisiteInstructions: TransactionInstruction[] = []
-  let serializedInstruction: string = ''
+  let serializedInstruction = ''
 
   if (
     isValid &&

--- a/utils/uiTypes/proposalCreationTypes.ts
+++ b/utils/uiTypes/proposalCreationTypes.ts
@@ -50,6 +50,14 @@ export interface SendTokenCompactViewForm extends SplTokenTransferForm {
   title: string
 }
 
+export interface StakingViewForm {
+  destinationAccount: string
+  amount: number | undefined
+  governedTokenAccount: GovernedTokenAccount | undefined
+  description: string
+  title: string
+}
+
 export interface MintForm {
   destinationAccount: string
   amount: number | undefined

--- a/utils/uiTypes/proposalCreationTypes.ts
+++ b/utils/uiTypes/proposalCreationTypes.ts
@@ -51,7 +51,7 @@ export interface SendTokenCompactViewForm extends SplTokenTransferForm {
 }
 
 export interface StakingViewForm {
-  destinationAccount: string
+  destinationAccount: GovernedTokenAccount | undefined
   amount: number | undefined
   governedTokenAccount: GovernedTokenAccount | undefined
   description: string


### PR DESCRIPTION
Added "Convert to mSOL" button below "Send" and "Deposit" buttons in native treasury overview. Button launches modal to create proposal on staking instruction generated by Marinade's SDK. Only tested on devnet testinstance V2.