### PR TITLE
Added button on "DAO creation page" to link to GovUI docs

### DIFF
--- a/components/RealmWizard/components/Steps/WizardModeSelect.tsx
+++ b/components/RealmWizard/components/Steps/WizardModeSelect.tsx
@@ -53,7 +53,7 @@ const WizardModeSelect: React.FC<{
         >
           <div className="border rounded px-4 py-1.5 hover:bg-bkg-3 pointer mt-10 ">
             <p>
-              <b>Tutorial</b>
+              <b>Tutorial Docs</b>
             </p>
           </div>
         </a>

--- a/components/RealmWizard/components/Steps/WizardModeSelect.tsx
+++ b/components/RealmWizard/components/Steps/WizardModeSelect.tsx
@@ -45,6 +45,19 @@ const WizardModeSelect: React.FC<{
           </div>
         </div>
       </div>
+      <div className="flex justify-center">
+        <a
+          href="https://governance-docs.vercel.app/multisig-DAO/create-multisig-DAO/DAO-wizard"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          <div className="border rounded px-4 py-1.5 hover:bg-bkg-3 pointer mt-10 ">
+            <p>
+              <b>Tutorial</b>
+            </p>
+          </div>
+        </a>
+      </div>
     </>
   )
 }

--- a/components/RealmWizard/components/Steps/WizardModeSelect.tsx
+++ b/components/RealmWizard/components/Steps/WizardModeSelect.tsx
@@ -51,10 +51,8 @@ const WizardModeSelect: React.FC<{
           target="_blank"
           rel="noopener noreferrer"
         >
-          <div className="border rounded px-4 py-1.5 hover:bg-bkg-3 pointer mt-10 ">
-            <p>
-              <b>Tutorial Docs</b>
-            </p>
+          <div className="border rounded px-3 py-1.5 hover:border-primary-light hover:bg-bkg-3 hover:text-primary-dark transition-all duration-200 pointer mt-10 ">
+            <span className="font-semibold text-sm">Tutorial Docs</span>
           </div>
         </a>
       </div>


### PR DESCRIPTION
Wanted there to be a clear direction to head incase a new user needs instructions or clarifications on how to create a DAO. 
The button links to [here](https://governance-docs.vercel.app/multisig-DAO/create-multisig-DAO/DAO-wizard), making it easier than to scroll down to the "docs" and have to search through there.

![1e23c67c4c512619d16261aada3c2a10](https://user-images.githubusercontent.com/59552589/153970479-694bf48d-d57d-4a96-a6ec-7f486d448863.png)

Something to mention here, it's difficult to know that there is the footer bar with the scroll bar being black. Was wondering if we could change the overall height of this page so there is no need to scroll down?

![8c00a489045bf688e894d7495af77784](https://user-images.githubusercontent.com/59552589/153970489-730ef967-871b-40ff-a0d5-1c2f6da3a0a1.png)
 