### PR TITLE
governance discord notifier: add support for private rpc, also sleep only when private rpc is not used

### DIFF
--- a/scripts/api.ts
+++ b/scripts/api.ts
@@ -54,8 +54,12 @@ export async function getGovernanceAccounts<TAccount extends GovernanceAccount>(
         filters
       )),
     }
-    // XXX: sleep to prevent public RPC rate limits
-    await sleep(3_000)
+
+    // note: if we are not using a specific RPC, then most probably we are using a public RPC
+    // sleep to prevent public RPC rate limits
+    if (!process.env.CLUSTER_URL) {
+      await sleep(3_000)
+    }
   }
 
   return accounts

--- a/scripts/governance-notifier.ts
+++ b/scripts/governance-notifier.ts
@@ -21,7 +21,8 @@ function errorWrapper() {
 async function runNotifier() {
   const nowInSeconds = new Date().getTime() / 1000
 
-  const MAINNET_RPC_NODE = 'https://api.mainnet-beta.solana.com'
+  const MAINNET_RPC_NODE =
+    process.env.CLUSTER_URL || 'https://api.mainnet-beta.solana.com'
   const connectionContext = getConnectionContext('mainnet')
 
   const REALM_SYMBOL = process.env.REALM_SYMBOL || 'MNGO'


### PR DESCRIPTION
I was running the governance discord notifier from a fork, would like to get some of the changes merged here.

Signed-off-by: microwavedcola1 <microwavedcola@gmail.com>