### PR TITLE
Removed spare circle icon for multiple instructions executed successf…

### DIFF
--- a/components/instructions/ExecuteAllInstructionButton.tsx
+++ b/components/instructions/ExecuteAllInstructionButton.tsx
@@ -87,18 +87,6 @@ export function ExecuteAllInstructionButton({
   }
 
   if (
-    proposalInstructions.every(
-      (x) => x.account.executionStatus === InstructionExecutionStatus.Success
-    )
-  ) {
-    return (
-      <Tooltip content="instruction executed successfully">
-        <CheckCircleIcon className="h-5 ml-2 text-green w-5" />
-      </Tooltip>
-    )
-  }
-
-  if (
     ![
       ProposalState.Executing,
       ProposalState.ExecutingWithErrors,


### PR DESCRIPTION
The redundant circle tick icon in the instructions panel has been removed.

This occurred when all instructions of one proposal have been completed successfully as each instruction has its own circle tick icon already.