### PR TITLE
Fix Strangemood Foundation

### DIFF
--- a/public/realms/mainnet-beta.json
+++ b/public/realms/mainnet-beta.json
@@ -150,7 +150,7 @@
     "symbol": "MOOD",
     "displayName": "Strangemood Foundation",
     "programId": "smfjietFKFJ4Sbw1cqESBTpPhF4CwbMwN8kBEC1e5ui",
-    "realmId": "FvzZFjf3NPTZbKAmQA4Gf1v7uTW7HFcP5Pcr2oVm49t3",
+    "realmId": "Dmn5q2SwkjZBKJGwULEWzK8zeZ2ES6JQvHKB297tAHXY",
     "ogImage": "/realms/strangemood/img/logo.svg",
     "website": "https://strangemood.org"
   },


### PR DESCRIPTION
We messed up when originally creating our realm, and so had to create another one. :( 

This sets the charted DAO to the correct one. 