### PR TITLE
add empty states to treasury and assets panels

### DIFF
--- a/components/AssetsList/AssetsCompactWrapper.tsx
+++ b/components/AssetsList/AssetsCompactWrapper.tsx
@@ -3,28 +3,78 @@ import AssetsList from './AssetsList'
 import { ChevronRightIcon } from '@heroicons/react/solid'
 import useRealm from '@hooks/useRealm'
 import useQueryContext from '@hooks/useQueryContext'
+import useWalletStore from 'stores/useWalletStore'
 import Link from 'next/link'
+import { useRouter } from 'next/router'
+import { TerminalIcon } from '@heroicons/react/outline'
+import useGovernanceAssets from '@hooks/useGovernanceAssets'
+import { GovernanceAccountType } from '@solana/spl-governance'
+import EmptyState from '@components/EmptyState'
+import {
+  NEW_PROGRAM_VIEW,
+  renderAddNewAssetTooltip,
+} from 'pages/dao/[symbol]/assets'
 
 const AssetsCompactWrapper = () => {
-  const { symbol } = useRealm()
+  const router = useRouter()
   const { fmtUrlWithCluster } = useQueryContext()
+  const {
+    symbol,
+    realm,
+    ownVoterWeight,
+    toManyCommunityOutstandingProposalsForUser,
+    toManyCouncilOutstandingProposalsForUse,
+  } = useRealm()
+  const connected = useWalletStore((s) => s.connected)
+  const canCreateGovernance = realm
+    ? ownVoterWeight.canCreateGovernance(realm)
+    : null
+
+  const newAssetToolTip = renderAddNewAssetTooltip(
+    connected,
+    canCreateGovernance,
+    toManyCommunityOutstandingProposalsForUser,
+    toManyCouncilOutstandingProposalsForUse
+  )
+
+  const goToNewAssetForm = () => {
+    router.push(fmtUrlWithCluster(`/dao/${symbol}${NEW_PROGRAM_VIEW}`))
+  }
+  const { getGovernancesByAccountTypes } = useGovernanceAssets()
+  const programGovernances = getGovernancesByAccountTypes([
+    GovernanceAccountType.ProgramGovernanceV1,
+    GovernanceAccountType.ProgramGovernanceV2,
+  ])
 
   return (
     <div className="bg-bkg-2 p-4 md:p-6 rounded-lg">
       <div className="flex items-center justify-between pb-4">
-        <h3 className="mb-0">Assets</h3>
-        <Link href={fmtUrlWithCluster(`/dao/${symbol}/assets`)}>
-          <a
-            className={`default-transition flex items-center text-fgd-2 text-sm transition-all hover:text-fgd-3`}
-          >
-            View
-            <ChevronRightIcon className="flex-shrink-0 h-6 w-6" />
-          </a>
-        </Link>
+        <h3 className="mb-0">Programs</h3>
+        {programGovernances.length > 0 ? (
+          <Link href={fmtUrlWithCluster(`/dao/${symbol}/assets`)}>
+            <a
+              className={`default-transition flex items-center text-fgd-2 text-sm transition-all hover:text-fgd-3`}
+            >
+              View
+              <ChevronRightIcon className="flex-shrink-0 h-6 w-6" />
+            </a>
+          </Link>
+        ) : null}
       </div>
-      <div className="overflow-y-auto" style={{ maxHeight: '350px' }}>
-        <AssetsList panelView />
-      </div>
+      {programGovernances.length > 0 ? (
+        <div className="overflow-y-auto" style={{ maxHeight: '350px' }}>
+          <AssetsList panelView />
+        </div>
+      ) : (
+        <EmptyState
+          desc="No programs found"
+          disableButton={!!newAssetToolTip}
+          buttonText="New Program"
+          icon={<TerminalIcon />}
+          onClickButton={goToNewAssetForm}
+          toolTipContent={newAssetToolTip}
+        />
+      )}
     </div>
   )
 }

--- a/components/EmptyState.tsx
+++ b/components/EmptyState.tsx
@@ -1,0 +1,52 @@
+import { FunctionComponent, ReactNode } from 'react'
+import { LinkButton } from './Button'
+import Tooltip from './Tooltip'
+
+interface EmptyStateProps {
+  buttonText?: string
+  disableButton?: boolean
+  icon?: ReactNode
+  onClickButton?: () => void
+  desc?: string
+  title?: string
+  toolTipContent?: string
+}
+
+const EmptyState: FunctionComponent<EmptyStateProps> = ({
+  buttonText,
+  disableButton,
+  icon,
+  onClickButton,
+  desc,
+  title,
+  toolTipContent,
+}) => {
+  return (
+    <div className="border border-bkg-4 flex flex-col items-center rounded-lg p-4 text-fgd-1">
+      {icon ? <div className="mb-1 h-6 w-6 text-fgd-3">{icon}</div> : null}
+      {title ? <h2 className="mb-1 text-base">{title}</h2> : null}
+      {desc ? (
+        <p
+          className={`text-center ${
+            buttonText && onClickButton ? 'mb-1' : 'mb-0'
+          }`}
+        >
+          {desc}
+        </p>
+      ) : null}
+      {buttonText && onClickButton ? (
+        <Tooltip content={toolTipContent}>
+          <LinkButton
+            className="text-primary-light"
+            disabled={disableButton}
+            onClick={onClickButton}
+          >
+            {buttonText}
+          </LinkButton>
+        </Tooltip>
+      ) : null}
+    </div>
+  )
+}
+
+export default EmptyState

--- a/components/TreasuryAccount/AccountsCompactWrapper.tsx
+++ b/components/TreasuryAccount/AccountsCompactWrapper.tsx
@@ -3,34 +3,72 @@ import HoldTokensTotalPrice from './HoldTokensTotalPrice'
 import useRealm from '@hooks/useRealm'
 import React from 'react'
 import { ChevronRightIcon } from '@heroicons/react/solid'
+import { CurrencyDollarIcon } from '@heroicons/react/outline'
 import useQueryContext from '@hooks/useQueryContext'
 import useGovernanceAssets from '@hooks/useGovernanceAssets'
 import Link from 'next/link'
+import { useRouter } from 'next/router'
+import EmptyState from '@components/EmptyState'
+import { NEW_TREASURY_ROUTE } from 'pages/dao/[symbol]/treasury'
+import useWalletStore from 'stores/useWalletStore'
 
 const AccountsCompactWrapper = () => {
-  const { fmtUrlWithCluster } = useQueryContext()
-  const { symbol } = useRealm()
   const { governedTokenAccounts } = useGovernanceAssets()
+  const {
+    ownVoterWeight,
+    symbol,
+    realm,
+    toManyCommunityOutstandingProposalsForUser,
+    toManyCouncilOutstandingProposalsForUse,
+  } = useRealm()
+  const router = useRouter()
+  const { fmtUrlWithCluster } = useQueryContext()
+  const connected = useWalletStore((s) => s.connected)
+
+  const goToNewAccountForm = () => {
+    router.push(fmtUrlWithCluster(`/dao/${symbol}${NEW_TREASURY_ROUTE}`))
+  }
+
+  const canCreateGovernance = realm
+    ? ownVoterWeight.canCreateGovernance(realm)
+    : null
+  const isConnectedWithGovernanceCreationPermission =
+    connected &&
+    canCreateGovernance &&
+    !toManyCommunityOutstandingProposalsForUser &&
+    !toManyCouncilOutstandingProposalsForUse
 
   return (
     <div className="bg-bkg-2 p-4 md:p-6 rounded-lg transition-all">
       <div className="flex items-center justify-between pb-4">
         <h3 className="mb-0">Treasury</h3>
-        <Link href={fmtUrlWithCluster(`/dao/${symbol}/treasury`)}>
-          <a
-            className={`default-transition flex items-center text-fgd-2 text-sm transition-all hover:text-fgd-3`}
-          >
-            View
-            <ChevronRightIcon className="flex-shrink-0 h-6 w-6" />
-          </a>
-        </Link>
+        {governedTokenAccounts.find((acc) => !acc.isNft) ? (
+          <Link href={fmtUrlWithCluster(`/dao/${symbol}/treasury`)}>
+            <a
+              className={`default-transition flex items-center text-fgd-2 text-sm transition-all hover:text-fgd-3`}
+            >
+              View
+              <ChevronRightIcon className="flex-shrink-0 h-6 w-6" />
+            </a>
+          </Link>
+        ) : null}
       </div>
       <HoldTokensTotalPrice />
-      <div style={{ maxHeight: '350px' }} className="overflow-y-auto">
-        {governedTokenAccounts.every((x) => x.transferAddress) && (
-          <AccountsItems />
-        )}
-      </div>
+      {governedTokenAccounts.find((acc) => !acc.isNft) ? (
+        <div style={{ maxHeight: '350px' }} className="overflow-y-auto">
+          {governedTokenAccounts.every((x) => x.transferAddress) && (
+            <AccountsItems />
+          )}
+        </div>
+      ) : (
+        <EmptyState
+          desc="No treasury accounts found"
+          disableButton={!isConnectedWithGovernanceCreationPermission}
+          buttonText="New Treasury Account"
+          icon={<CurrencyDollarIcon />}
+          onClickButton={goToNewAccountForm}
+        />
+      )}
     </div>
   )
 }

--- a/pages/dao/[symbol]/assets/index.tsx
+++ b/pages/dao/[symbol]/assets/index.tsx
@@ -8,7 +8,7 @@ import useWalletStore from 'stores/useWalletStore'
 import PreviousRouteBtn from '@components/PreviousRouteBtn'
 import { LinkButton } from '@components/Button'
 import { PlusCircleIcon } from '@heroicons/react/outline'
-const NEW_PROGRAM_VIEW = `/program/new`
+export const NEW_PROGRAM_VIEW = `/program/new`
 
 const Assets = () => {
   const router = useRouter()
@@ -28,15 +28,22 @@ const Assets = () => {
     ? ownVoterWeight.canCreateGovernance(realm)
     : null
 
-  const addNewAssetTooltip = !connected
-    ? 'Connect your wallet to create new asset'
-    : !canCreateGovernance
-    ? "You don't have enough governance power to create a new asset"
-    : toManyCommunityOutstandingProposalsForUser
-    ? 'You have too many community outstanding proposals. You need to finalize them before creating a new asset.'
-    : toManyCouncilOutstandingProposalsForUse
-    ? 'You have too many council outstanding proposals. You need to finalize them before creating a new asset.'
-    : ''
+  const newAssetToolTip = renderAddNewAssetTooltip(
+    connected,
+    canCreateGovernance,
+    toManyCommunityOutstandingProposalsForUser,
+    toManyCouncilOutstandingProposalsForUse
+  )
+
+  // const addNewAssetTooltip = !connected
+  //   ? 'Connect your wallet to create new asset'
+  //   : !canCreateGovernance
+  //   ? "You don't have enough governance power to create a new asset"
+  //   : toManyCommunityOutstandingProposalsForUser
+  //   ? 'You have too many community outstanding proposals. You need to finalize them before creating a new asset.'
+  //   : toManyCouncilOutstandingProposalsForUse
+  //   ? 'You have too many council outstanding proposals. You need to finalize them before creating a new asset.'
+  //   : ''
   return (
     <div className="bg-bkg-2 rounded-lg p-4 md:p-6">
       <div className="grid grid-cols-12 gap-6">
@@ -45,12 +52,12 @@ const Assets = () => {
             <PreviousRouteBtn />
           </div>
           <div className="flex items-center justify-between mb-4">
-            <h1 className="mb-0">Assets</h1>
-            <Tooltip contentClassName="ml-auto" content={addNewAssetTooltip}>
+            <h1 className="mb-0">Programs</h1>
+            <Tooltip contentClassName="ml-auto" content={newAssetToolTip}>
               <LinkButton
                 onClick={goToNewAssetForm}
                 className={`flex items-center text-primary-light ${
-                  addNewAssetTooltip
+                  newAssetToolTip
                     ? 'cursor-not-allowed pointer-events-none opacity-60'
                     : 'cursor-pointer'
                 }`}
@@ -68,3 +75,20 @@ const Assets = () => {
 }
 
 export default Assets
+
+export const renderAddNewAssetTooltip = (
+  connected,
+  canCreateGovernance,
+  toManyCommunityOutstandingProposalsForUser,
+  toManyCouncilOutstandingProposalsForUse
+) => {
+  return !connected
+    ? 'Connect your wallet to create new asset'
+    : !canCreateGovernance
+    ? "You don't have enough governance power to create a new asset"
+    : toManyCommunityOutstandingProposalsForUser
+    ? 'You have too many community outstanding proposals. You need to finalize them before creating a new asset.'
+    : toManyCouncilOutstandingProposalsForUse
+    ? 'You have too many council outstanding proposals. You need to finalize them before creating a new asset.'
+    : ''
+}

--- a/pages/dao/[symbol]/treasury/index.tsx
+++ b/pages/dao/[symbol]/treasury/index.tsx
@@ -17,7 +17,7 @@ import useStrategiesStore from 'Strategies/store/useStrategiesStore'
 import Select from '@components/inputs/Select'
 import { getTreasuryAccountItemInfo } from '@utils/treasuryTools'
 
-const NEW_TREASURY_ROUTE = `/treasury/new`
+export const NEW_TREASURY_ROUTE = `/treasury/new`
 
 const Treasury = () => {
   const { getStrategies } = useStrategiesStore()


### PR DESCRIPTION
Can we show NFT accounts in the Treasury Accounts panel? Otherwise, for DAOs that only have an NFT account, nothing shows in the panel but if you go to the page there will be an account.

Are "Assets" ever anything other than programs? If not, I think the panel/page title should be "Programs"

Added these states:
<img width="368" alt="Screen Shot 2022-03-23 at 10 52 31 am" src="https://user-images.githubusercontent.com/30796577/159595459-220e68f0-9ddb-42fd-b91e-9b54163ee70d.png">

<img width="369" alt="Screen Shot 2022-03-23 at 10 50 25 am" src="https://user-images.githubusercontent.com/30796577/159595280-43487cd3-eb4f-49c5-8f21-74a9adf0b378.png">


