### PR TITLE
Fixing link to Gov docs

### DIFF
--- a/components/RealmWizard/components/Steps/WizardModeSelect.tsx
+++ b/components/RealmWizard/components/Steps/WizardModeSelect.tsx
@@ -47,7 +47,7 @@ const WizardModeSelect: React.FC<{
       </div>
       <div className="flex justify-center">
         <a
-          href="https://governance-docs.vercel.app/multisig-DAO/create-multisig-DAO/DAO-wizard"
+          href="https://governance-docs.vercel.app/DAO-Management/createing-DAOs/DAO-wizard"
           target="_blank"
           rel="noopener noreferrer"
         >


### PR DESCRIPTION
Fixed broken link to the Governance UI Docs on the "Create DAO" menu. 

<img src="https://user-images.githubusercontent.com/59552589/161635435-9c0f3260-310e-4e28-9701-3513e7fd3b5b.png" width="550" height="250" />

<img src="https://user-images.githubusercontent.com/59552589/161635771-7c26b39e-0ff9-4e30-8243-780e590a5253.png" width="550" height="250"  />

