### PR TITLE
Feature/code security scanning

### DIFF
--- a/.github/workflows/codeql-scan.yml
+++ b/.github/workflows/codeql-scan.yml
@@ -1,0 +1,34 @@
+name: 'CodeQL Scan'
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  analyze:
+    name: CodeQL Analysis
+    runs-on: ubuntu-latest
+    if: (github.actor != 'dependabot[bot]') # Skip PRs created by dependabot to avoid permission issues
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+
+    strategy:
+      fail-fast: false
+      matrix:
+        language: [ 'javascript' ]
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v2
+
+    - name: Initialise CodeQL
+      uses: github/codeql-action/init@v1
+      with:
+        languages: ${{ matrix.language }}
+    
+    - name: Run CodeQL
+      uses: github/codeql-action/analyze@v1

--- a/utils/github.ts
+++ b/utils/github.ts
@@ -13,7 +13,7 @@ export async function fetchGistFile(gistUrl: string) {
         const jsonContent = await apiResponse.json()
         const nextUrlFileName = Object.keys(jsonContent['files'])[0]
         const nextUrl = jsonContent['files'][nextUrlFileName]['raw_url']
-        if (nextUrl.startsWith('https://gist.githubusercontent.com')) {
+        if (nextUrl.startsWith('https://gist.githubusercontent.com/')) {
           const fileResponse = await fetch(nextUrl)
 
           //console.log('fetchGistFile file', gistUrl, fileResponse)

--- a/utils/github.ts
+++ b/utils/github.ts
@@ -1,6 +1,6 @@
 const urlRegex =
   // eslint-disable-next-line
-  /(https:\/\/)(gist.github.com\/)([\w\/]{1,39}\/)([\w]{1,32})/
+  /(https:\/\/)(gist\.github.com\/)([\w\/]{1,39}\/)([\w]{1,32})/
 
 export async function fetchGistFile(gistUrl: string) {
   const pieces = gistUrl.match(urlRegex)


### PR DESCRIPTION
PR replaces https://github.com/solana-labs/governance-ui/pull/227 to simplify.

Adds CodeQL static code security scanning for JS/TS. When it detects potentially vulnerable code, it raises a security issue under the security tab with suggested fixes. Can be ignored and muted if false positive.

Also includes small security tweak to github URL regex.