### PR TITLE
'Token' on About tab should show mint rather than realm pubkey

### DIFF
--- a/components/AboutRealm.tsx
+++ b/components/AboutRealm.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 import useRealm from 'hooks/useRealm'
 
 const AboutRealm = () => {
-  const { realmInfo, realmDisplayName, symbol } = useRealm()
+  const { realmInfo, realmDisplayName, mint } = useRealm()
 
   return (
     <div className="pb-4 space-y-3">
@@ -12,7 +12,7 @@ const AboutRealm = () => {
       </div>
       <div>
         <p className="text-xs text-fgd-3">Token</p>
-        <p className="text-fgd-1">{symbol}</p>
+        <p className="text-fgd-1">{mint}</p>
       </div>
       {realmInfo?.website ? (
         <div>

--- a/components/AboutRealm.tsx
+++ b/components/AboutRealm.tsx
@@ -2,7 +2,7 @@ import React from 'react'
 import useRealm from 'hooks/useRealm'
 
 const AboutRealm = () => {
-  const { realmInfo, realmDisplayName, mint } = useRealm()
+  const { realmInfo, realmDisplayName, symbol } = useRealm()
 
   return (
     <div className="pb-4 space-y-3">
@@ -10,10 +10,12 @@ const AboutRealm = () => {
         <p className="text-xs text-fgd-3">Name</p>
         <p className="text-fgd-1">{realmDisplayName || symbol}</p>
       </div>
-      <div>
-        <p className="text-xs text-fgd-3">Token</p>
-        <p className="text-fgd-1">{mint}</p>
-      </div>
+      {realmInfo?.isCertified ? (
+        <div>
+          <p className="text-xs text-fgd-3">Token</p>
+          <p className="text-fgd-1">{symbol}</p>
+        </div>
+      ) : null}
       {realmInfo?.website ? (
         <div>
           <p className="text-xs text-fgd-3">Website</p>


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/10570340/166403017-aeede4d0-3b65-4b44-b5cd-2a47a419b3af.png)

The 'Token' section of this tab is actually showing the pubkey of the Realm itself. I believe based on the name it should probably show the community token mint instead.