### PR TITLE
Refresh connected wallet when user changes wallet addresses

### DIFF
--- a/hooks/useWallet.tsx
+++ b/hooks/useWallet.tsx
@@ -27,6 +27,21 @@ export default function useWallet() {
     DEFAULT_PROVIDER.url
   )
 
+  async function flipWalletByTurningOffAndOn() {
+    if (wallet) {
+      try {
+        await wallet.disconnect()
+        await wallet.connect()
+      } catch (error) {
+        const err = error as Error
+        return notify({
+          type: 'error',
+          message: err.message,
+        })
+      }
+    }
+  }
+
   // initialize selection from local storage
   useEffect(() => {
     if (!selectedProviderUrl) {
@@ -117,7 +132,16 @@ export default function useWallet() {
   // refresh regularly
   useInterval(async () => {
     console.log('refresh')
-  }, 10 * SECONDS)
+    // @ts-ignore
+    const currentAddress = window?.solana?._publicKey.toBase58()
+    const staleAddress = wallet?.publicKey?.toString()
+    if (staleAddress !== currentAddress) {
+      console.log(
+        `Wallet address changed from ${staleAddress} to ${currentAddress}`
+      )
+      flipWalletByTurningOffAndOn()
+    }
+  }, 3 * SECONDS)
 
   return { connected, wallet }
 }


### PR DESCRIPTION
User should see their new wallet address reflected in the WalletConnectButton whenever they change their account (e.g. in phantom from one wallet to another).

Unfortunately, this uses polling to crudely compare the given state of the address stored locally, and the address directly referenced by `window.solana`. Ideally, we would use a wallet event, but those are not yet mature / merged into the wallet adapter repo at the moment.