### PR TITLE
Add ability to transfer program authority

### DIFF
--- a/components/AssetsList/AssetItem.tsx
+++ b/components/AssetsList/AssetItem.tsx
@@ -14,6 +14,7 @@ import Modal from '@components/Modal'
 import UpgradeProgram from './UpgradeProgram'
 import CloseBuffers from './CloseBuffers'
 import { getExplorerUrl } from '@components/explorer/tools'
+import TransferUpgradeAuthority from './TransferUpgradeAuthority'
 
 const AssetItem = ({
   item,
@@ -26,6 +27,9 @@ const AssetItem = ({
   const [slot, setSlot] = useState(0)
   const [openUpgradeModal, setOpenUpgradeModal] = useState(false)
   const [openCloseBuffersModal, setOpenCloseBuffersModal] = useState(false)
+  const [openTransferAuthorityModal, setOpenTransferAuthorityModal] = useState(
+    false
+  )
   const [loadSlot, setLoadSlot] = useState(false)
   const connection = useWalletStore((s) => s.connection)
   const name = item ? getProgramName(item.account.governedAccount) : ''
@@ -116,6 +120,20 @@ const AssetItem = ({
                 <div>Close Buffers</div>
               </Tooltip>
             </SecondaryButton>
+            <SecondaryButton
+              className="sm:w-1/2 text-sm"
+              onClick={() => setOpenTransferAuthorityModal(true)}
+              disabled={!canUseProgramUpgradeInstruction}
+            >
+              <Tooltip
+                content={
+                  !canUseProgramUpgradeInstruction &&
+                  'You need to have connected wallet with ability to create upgrade proposals'
+                }
+              >
+                <div>Transfer Authority</div>
+              </Tooltip>
+            </SecondaryButton>
           </div>
         </>
       )}
@@ -137,6 +155,16 @@ const AssetItem = ({
           isOpen={openCloseBuffersModal}
         >
           <CloseBuffers program={item} />
+        </Modal>
+      )}
+      {openTransferAuthorityModal && (
+        <Modal
+          onClose={() => {
+            setOpenTransferAuthorityModal(false)
+          }}
+          isOpen={openTransferAuthorityModal}
+        >
+          <TransferUpgradeAuthority program={item} />
         </Modal>
       )}
     </div>

--- a/components/AssetsList/TransferUpgradeAuthority.tsx
+++ b/components/AssetsList/TransferUpgradeAuthority.tsx
@@ -1,0 +1,254 @@
+import { ChevronDownIcon } from '@heroicons/react/solid'
+import { PublicKey } from '@solana/web3.js'
+import useRealm from 'hooks/useRealm'
+import Input from 'components/inputs/Input'
+import Button, { LinkButton } from '@components/Button'
+import Textarea from 'components/inputs/Textarea'
+import VoteBySwitch from 'pages/dao/[symbol]/proposal/components/VoteBySwitch'
+import useWalletStore from 'stores/useWalletStore'
+import { getValidatedPublickKey } from 'utils/validations'
+import { useEffect, useState } from 'react'
+import { UiInstruction } from 'utils/uiTypes/proposalCreationTypes'
+import { serializeInstructionToBase64 } from '@solana/spl-governance'
+import { useRouter } from 'next/router'
+import { notify } from 'utils/notifications'
+import useQueryContext from 'hooks/useQueryContext'
+import { validateInstruction } from 'utils/instructionTools'
+import * as yup from 'yup'
+import useCreateProposal from '@hooks/useCreateProposal'
+import { InstructionDataWithHoldUpTime } from 'actions/createProposal'
+import { createSetUpgradeAuthority } from '@tools/sdk/bpfUpgradeableLoader/createSetUpgradeAuthority'
+import { abbreviateAddress } from '@utils/formatting'
+import useGovernanceAssets from '@hooks/useGovernanceAssets'
+import { Governance, ProgramAccount } from '@solana/spl-governance'
+import { AssetAccount } from '@utils/uiTypes/assets'
+
+interface CloseBuffersForm {
+  governedAccount: AssetAccount | undefined
+  programId: string | undefined
+  newUpgradeAuthority: string
+  description: string
+  title: string
+}
+
+const TransferUpgradeAuthority = ({
+  program,
+}: {
+  program: ProgramAccount<Governance>
+}) => {
+  const { handleCreateProposal } = useCreateProposal()
+  const { assetAccounts } = useGovernanceAssets()
+  const router = useRouter()
+  const wallet = useWalletStore((s) => s.current)
+  const governedAccount = assetAccounts.find(
+    (x) => x.governance.pubkey.toBase58() === program.pubkey.toBase58()
+  )
+  const { fmtUrlWithCluster } = useQueryContext()
+  const { symbol } = router.query
+  const { realmInfo, canChooseWhoVote, realm } = useRealm()
+  const programId: PublicKey | undefined = realmInfo?.programId
+
+  const [form, setForm] = useState<CloseBuffersForm>({
+    governedAccount: governedAccount,
+    programId: programId?.toString(),
+    newUpgradeAuthority: wallet?.publicKey?.toBase58()
+      ? wallet?.publicKey?.toBase58()
+      : '',
+    description: '',
+    title: '',
+  })
+  const [voteByCouncil, setVoteByCouncil] = useState(false)
+  const [showOptions, setShowOptions] = useState(false)
+  const [isLoading, setIsLoading] = useState(false)
+  const [formErrors, setFormErrors] = useState({})
+  const proposalTitle = `Transfer upgrade authority for program ${
+    form.governedAccount?.governance?.account.governedAccount
+      ? abbreviateAddress(
+          form.governedAccount?.governance?.account.governedAccount
+        )
+      : ''
+  }`
+
+  const handleSetForm = ({ propertyName, value }) => {
+    setFormErrors({})
+    setForm({ ...form, [propertyName]: value })
+  }
+  const schema = yup.object().shape({
+    newUpgradeAuthority: yup
+      .string()
+      .test('accountTests', 'Account validation error', function (val: string) {
+        if (val) {
+          try {
+            return !!getValidatedPublickKey(val)
+          } catch (e) {
+            console.log(e)
+            return this.createError({
+              message: `${e}`,
+            })
+          }
+        } else {
+          return this.createError({
+            message: `New upgrade authority address is required`,
+          })
+        }
+      }),
+    governedAccount: yup
+      .object()
+      .nullable()
+      .required('Program governed account is required'),
+  })
+  async function getInstructions(): Promise<UiInstruction[]> {
+    const isValid = await validateInstruction({ schema, form, setFormErrors })
+    const instructions: UiInstruction[] = []
+    let serializedInstruction = ''
+    if (
+      isValid &&
+      programId &&
+      form.governedAccount?.governance?.account &&
+      wallet?.publicKey
+    ) {
+      const transferUpgradeAuthIx = await createSetUpgradeAuthority(
+        form.governedAccount.governance.account.governedAccount,
+        form.governedAccount.governance.pubkey,
+        new PublicKey(form.newUpgradeAuthority)
+      )
+      serializedInstruction = serializeInstructionToBase64(
+        transferUpgradeAuthIx
+      )
+    }
+    const obj: UiInstruction = {
+      serializedInstruction: serializedInstruction,
+      isValid,
+      governance: form.governedAccount?.governance,
+    }
+    instructions.push(obj)
+    return instructions
+  }
+  const handlePropose = async () => {
+    setIsLoading(true)
+    const instructions: UiInstruction[] = await getInstructions()
+    if (instructions.length && instructions[0].isValid) {
+      const governance = form.governedAccount?.governance
+      if (!realm) {
+        setIsLoading(false)
+        throw 'No realm selected'
+      }
+
+      const instructionsData = instructions.map(
+        (x) =>
+          new InstructionDataWithHoldUpTime({
+            instruction: x,
+            governance,
+          })
+      )
+      try {
+        const proposalAddress = await handleCreateProposal({
+          title: form.title ? form.title : proposalTitle,
+          description: form.description ? form.description : '',
+          voteByCouncil,
+          instructionsData: instructionsData,
+          governance: governance!,
+        })
+        const url = fmtUrlWithCluster(
+          `/dao/${symbol}/proposal/${proposalAddress}`
+        )
+        router.push(url)
+      } catch (ex) {
+        notify({ type: 'error', message: `${ex}` })
+      }
+    }
+    setIsLoading(false)
+  }
+
+  useEffect(() => {
+    handleSetForm({
+      propertyName: 'programId',
+      value: programId?.toString(),
+    })
+  }, [realmInfo?.programId])
+
+  return (
+    <>
+      <h3 className="mb-4 flex items-center hover:cursor-pointer">
+        Transfer upgrade authority
+      </h3>
+      <div className="space-y-4">
+        <Input
+          label="New upgrade authority"
+          value={form.newUpgradeAuthority}
+          type="text"
+          onChange={(evt) =>
+            handleSetForm({
+              value: evt.target.value,
+              propertyName: 'newUpgradeAuthority',
+            })
+          }
+          noMaxWidth={true}
+          error={formErrors['newUpgradeAuthority']}
+        />
+
+        <LinkButton
+          className="flex items-center text-primary-light"
+          onClick={() => setShowOptions(!showOptions)}
+        >
+          {showOptions ? 'Less Options' : 'More Options'}
+          <ChevronDownIcon
+            className={`default-transition h-5 w-5 ml-1 ${
+              showOptions ? 'transform rotate-180' : 'transform rotate-360'
+            }`}
+          />
+        </LinkButton>
+        {showOptions && (
+          <>
+            <Input
+              noMaxWidth={true}
+              label="Proposal Title"
+              placeholder={proposalTitle}
+              value={form.title}
+              type="text"
+              onChange={(evt) =>
+                handleSetForm({
+                  value: evt.target.value,
+                  propertyName: 'title',
+                })
+              }
+            />
+            <Textarea
+              noMaxWidth={true}
+              label="Proposal Description"
+              placeholder={
+                'Description of your proposal or use a github gist link (optional)'
+              }
+              wrapperClassName="mb-5"
+              value={form.description}
+              onChange={(evt) =>
+                handleSetForm({
+                  value: evt.target.value,
+                  propertyName: 'description',
+                })
+              }
+            />
+            {canChooseWhoVote && (
+              <VoteBySwitch
+                checked={voteByCouncil}
+                onChange={() => {
+                  setVoteByCouncil(!voteByCouncil)
+                }}
+              />
+            )}
+          </>
+        )}
+      </div>
+      <Button
+        className="mt-6"
+        onClick={handlePropose}
+        isLoading={isLoading}
+        disabled={isLoading}
+      >
+        <div>Propose Transfer Upgrade Authority</div>
+      </Button>
+    </>
+  )
+}
+
+export default TransferUpgradeAuthority

--- a/tools/sdk/bpfUpgradeableLoader/createSetUpgradeAuthority.ts
+++ b/tools/sdk/bpfUpgradeableLoader/createSetUpgradeAuthority.ts
@@ -1,11 +1,13 @@
+import { BPF_UPGRADE_LOADER_ID } from '@solana/spl-governance'
 import { PublicKey, TransactionInstruction } from '@solana/web3.js'
 
 export async function createSetUpgradeAuthority(
   programId: PublicKey,
   upgradeAuthority: PublicKey,
-  newUpgradeAuthority: PublicKey,
-  bpfUpgradableLoaderId: PublicKey
+  newUpgradeAuthority: PublicKey
 ) {
+  const bpfUpgradableLoaderId = BPF_UPGRADE_LOADER_ID
+
   const [programDataAddress] = await PublicKey.findProgramAddress(
     [programId.toBuffer()],
     bpfUpgradableLoaderId


### PR DESCRIPTION
closes: https://github.com/solana-labs/governance-ui/issues/803

## Notes

* Even after the authority is transferred the program governance will still show up. Looking at the SPL Governance program there's no close program governance instruction. Because of this, the program still shows up as a governance asset. Is this a PR blocker? Potential solution:
    * Update the governance UI to filter program governances by upgrade authority (ensuring the governance still has the authority

* UI is a little squished on some sizes, but it's actually not terrible (screenshot below). Is this a blocker?
<img width="591" alt="Screen Shot 2022-06-28 at 7 09 10 PM" src="https://user-images.githubusercontent.com/32071703/176319106-daaaf678-d7df-4b96-a815-620dfd2313d1.png">
 