### PR TITLE
Bump, pass governance to updateVoterWeight when creating a proposal

### DIFF
--- a/actions/createProposal.ts
+++ b/actions/createProposal.ts
@@ -109,7 +109,8 @@ export const createProposal = async (
   const plugin = await client?.withUpdateVoterWeightRecord(
     instructions,
     tokenOwnerRecord,
-    'createProposal'
+    'createProposal',
+    governance
   )
 
   const proposalAddress = await withCreateProposal(

--- a/package.json
+++ b/package.json
@@ -82,7 +82,7 @@
     "next-themes": "^0.1.1",
     "next-transpile-modules": "^8.0.0",
     "node-fetch": "^2.6.1",
-    "pyth-staking-api": "^1.2.8",
+    "pyth-staking-api": "^1.2.17",
     "rc-slider": "^9.7.5",
     "react": "^18.1.0",
     "react-dom": "^18.0.0",

--- a/utils/uiTypes/VotePlugin.ts
+++ b/utils/uiTypes/VotePlugin.ts
@@ -241,6 +241,7 @@ export class VotingClient {
 
       const {
         voterWeightAccount,
+        maxVoterWeightRecord,
       } = await this.client.stakeConnection.withUpdateVoterWeight(
         instructions,
         stakeAccount!,
@@ -250,7 +251,7 @@ export class VotingClient {
 
       return {
         voterWeightPk: voterWeightAccount,
-        maxVoterWeightRecord: undefined,
+        maxVoterWeightRecord,
       }
     }
     if (this.client instanceof SwitchboardQueueVoterClient) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -12092,10 +12092,10 @@ purgecss@^4.0.3:
     postcss "^8.3.5"
     postcss-selector-parser "^6.0.6"
 
-pyth-staking-api@^1.2.8:
-  version "1.2.8"
-  resolved "https://registry.yarnpkg.com/pyth-staking-api/-/pyth-staking-api-1.2.8.tgz#09dbc66f17bc1c0cc1c168815b86115c8c022ff1"
-  integrity sha512-majfEGXDNEYeDurJnoEdfy4GXojCnUoWikrArMcBgx9IpKSSnCUpmRv2pRbFC/xzvjOSN5sGXvGLGS5XfA6DMQ==
+pyth-staking-api@^1.2.17:
+  version "1.2.17"
+  resolved "https://registry.yarnpkg.com/pyth-staking-api/-/pyth-staking-api-1.2.17.tgz#c49db878cdd6b074d76ac6bf09f6d7d23b29ae50"
+  integrity sha512-rcjS9aq9NO1oq1/ynbynKSkGDg1dt1GwPdzb5GlchH5gTtZ9ANsdfM5ZdYZ1DMcLVk8kUaj/n/4u4nZ/98KTYw==
   dependencies:
     "@project-serum/anchor" "0.24.2"
     "@solana/spl-governance" "^0.0.34"


### PR DESCRIPTION
We made some changes to the Pyth staking package and so we need to update the governance UI to use the newest version of the package.

In parallel we also updated `createProposal` to pass the governance account as the target account to `withUpdateVoterWeightRecord`. This is the intended way to interact with the onchain spl-governance program.