### PR TITLE
Banner image could be distorted due to fixed banner height

### DIFF
--- a/pages/dao/[symbol]/index.tsx
+++ b/pages/dao/[symbol]/index.tsx
@@ -433,7 +433,7 @@ const REALM = () => {
                   {realmInfo?.bannerImage ? (
                     <>
                       <img
-                        className="mb-10 h-80"
+                        className="mb-10"
                         src={realmInfo?.bannerImage}
                       ></img>
                       {/* temp. setup for Ukraine.SOL */}


### PR DESCRIPTION
Problem description: 

The banner has a fixed height of 20 rem. On the other hand, the width is computed automatically.
As a result, banner images could be distorted.

Please take a look at the following DAOs:
https://realms.today/dao/AthensDAO
https://realms.today/dao/EVS/
https://realms.today/dao/Ukraine

Solution:
Remove unnecessary className that sets height to 20 rem.

Performed testing:
Make sure that various DAO banners are displayed properly without distortion