### PR TITLE
Modify error message for adding custom instruction

### DIFF
--- a/pages/dao/[symbol]/proposal/components/instructions/CustomBase64.tsx
+++ b/pages/dao/[symbol]/proposal/components/instructions/CustomBase64.tsx
@@ -74,7 +74,7 @@ const CustomBase64 = ({
     base64: yup
       .string()
       .required('Instruction is required')
-      .test('base64Test', 'Invalid base64', function (val: string) {
+      .test('base64Test', 'Invalid input. Must be base64 encoded governance program InstructionData', function (val: string) {
         if (val) {
           try {
             getInstructionDataFromBase64(val)


### PR DESCRIPTION
Seems the Realms UI wants an `InstructionData`, i.e., already wrapped instruction. I had assumed it would wrap that in the realms stuff for me, so my first attempts to dump base64 encoded instruction data from another program didn't work and I was confused.