### PR TITLE
FIX: Replace validateSolAddress

### DIFF
--- a/components/NewRealmWizard/components/TokenInput.tsx
+++ b/components/NewRealmWizard/components/TokenInput.tsx
@@ -6,7 +6,7 @@ import { PublicKey } from '@solana/web3.js'
 import { getMintSupplyAsDecimal } from '@tools/sdk/units'
 import useWalletStore from 'stores/useWalletStore'
 import { tryGetMint } from '@utils/tokens'
-import { validateSolAddress } from '@utils/formValidation'
+import { validatePubkey } from '@utils/formValidation'
 import { preventNegativeNumberInput } from '@utils/helpers'
 
 import { Controller } from 'react-hook-form'
@@ -114,7 +114,7 @@ export default function TokenInput({
       }
     }
 
-    if (tokenMintAddress && validateSolAddress(tokenMintAddress)) {
+    if (tokenMintAddress && validatePubkey(tokenMintAddress)) {
       getTokenInfo(tokenMintAddress)
     } else {
       setTokenInfo(undefined)

--- a/components/NewRealmWizard/components/steps/AddCouncilForm.tsx
+++ b/components/NewRealmWizard/components/steps/AddCouncilForm.tsx
@@ -10,7 +10,7 @@ import { RadioGroup } from '@components/NewRealmWizard/components/Input'
 import AdviceBox from '@components/NewRealmWizard/components/AdviceBox'
 import Text from '@components/Text'
 
-import { updateUserInput, validateSolAddress } from '@utils/formValidation'
+import { updateUserInput, validatePubkey } from '@utils/formValidation'
 import TokenInput, { TokenWithMintInfo, COUNCIL_TOKEN } from '../TokenInput'
 
 export const AddCouncilSchema = {
@@ -37,7 +37,7 @@ export const AddCouncilSchema = {
       otherwise: yup.string().optional(),
     })
     .test('is-valid-address', 'Please enter a valid Solana address', (value) =>
-      value ? validateSolAddress(value) : true
+      value ? validatePubkey(value) : true
     ),
   transferCouncilMintAuthority: yup
     .boolean()

--- a/components/NewRealmWizard/components/steps/AddNFTCollectionForm.tsx
+++ b/components/NewRealmWizard/components/steps/AddNFTCollectionForm.tsx
@@ -5,7 +5,7 @@ import * as yup from 'yup'
 import { deprecated } from '@metaplex-foundation/mpl-token-metadata'
 import axios from 'axios'
 
-import { updateUserInput, validateSolAddress } from '@utils/formValidation'
+import { updateUserInput, validatePubkey } from '@utils/formValidation'
 import { notify } from '@utils/notifications'
 import { abbreviateAddress } from '@utils/formatting'
 
@@ -286,7 +286,7 @@ export default function AddNFTCollectionForm({
   async function handleAdd(collectionInput) {
     clearErrors()
 
-    if (validateSolAddress(collectionInput)) {
+    if (validatePubkey(collectionInput)) {
       handleClearSelectedNFT(false)
       setRequestPending(true)
       try {

--- a/components/NewRealmWizard/components/steps/CommunityTokenDetailsForm.tsx
+++ b/components/NewRealmWizard/components/steps/CommunityTokenDetailsForm.tsx
@@ -4,7 +4,7 @@ import { yupResolver } from '@hookform/resolvers/yup'
 import * as yup from 'yup'
 
 import { preventNegativeNumberInput } from '@utils/helpers'
-import { updateUserInput, validateSolAddress } from '@utils/formValidation'
+import { updateUserInput, validatePubkey } from '@utils/formValidation'
 
 import FormHeader from '@components/NewRealmWizard/components/FormHeader'
 import FormField from '@components/NewRealmWizard/components/FormField'
@@ -27,7 +27,7 @@ export const CommunityTokenSchema = {
       otherwise: yup.string().optional(),
     })
     .test('is-valid-address', 'Please enter a valid Solana address', (value) =>
-      value ? validateSolAddress(value) : true
+      value ? validatePubkey(value) : true
     ),
   transferCommunityMintAuthority: yup
     .boolean()


### PR DESCRIPTION
Small PR to replace `validateSolAddress` which checks whether a given address is valid and lies on the ED25519 curve, with `validatePubkey` which checks only whether a given address is valid.

This allows users to enter PDAs that have been initialized as Mints as Community tokens and NFT collections.