### PR TITLE
Fix issue in propasal instructions going out of order

### DIFF
--- a/components/ProposalExecutionCard.tsx
+++ b/components/ProposalExecutionCard.tsx
@@ -39,7 +39,15 @@ function parseTransactions(
     }
   }
 
-  return { executed, ready, notReady, minHoldUpTime }
+  // Order instructions by instruction index
+  return {
+    executed,
+    ready: ready.sort(
+      (a, b) => a.account.instructionIndex - b.account.instructionIndex
+    ),
+    notReady,
+    minHoldUpTime,
+  }
 }
 
 interface Props {


### PR DESCRIPTION
There is an issue with Proposal Instructions going out of order when they are built for execution. Due to this you get errors when you execute a proposal as some instructions get executed before the other.

This PR mainly addresses this issue by ordering the proposal Instruction by its instruction index. To always run these instructions in the specified order.