### PR TITLE
Add maxVoterWeight address to UseVotePluginsClientStore and use it for finalizing proposals

### DIFF
--- a/components/ProposalActions.tsx
+++ b/components/ProposalActions.tsx
@@ -18,6 +18,7 @@ import { ProgramAccount } from '@solana/spl-governance'
 import { cancelProposal } from 'actions/cancelProposal'
 import { getProgramVersionForRealm } from '@models/registry/api'
 import useNftPluginStore from 'NftVotePlugin/store/nftPluginStore'
+import useVotePluginsClientStore from 'stores/useVotePluginsClientStore'
 
 const ProposalActionsPanel = () => {
   const { governance, proposal, proposalOwner } = useWalletStore(
@@ -32,7 +33,8 @@ const ProposalActionsPanel = () => {
   const refetchProposals = useWalletStore((s) => s.actions.refetchProposals)
   const [signatoryRecord, setSignatoryRecord] = useState<any>(undefined)
   const maxVoterWeight =
-    useNftPluginStore((s) => s.state.maxVoteRecord)?.pubkey || undefined
+    useNftPluginStore((s) => s.state.maxVoteRecord)?.pubkey ||
+    useVotePluginsClientStore((s) => s.state.maxVoterWeight)
   const canFinalizeVote =
     hasVoteTimeExpired && proposal?.account.state === ProposalState.Voting
 

--- a/stores/useVotePluginsClientStore.tsx
+++ b/stores/useVotePluginsClientStore.tsx
@@ -30,6 +30,7 @@ interface UseVotePluginsClientStore extends State {
     gatewayRegistrar: any
     currentRealmVotingClient: VotingClient
     voteStakeRegistryRegistrarPk: PublicKey | null
+    maxVoterWeight: PublicKey | undefined
   }
   handleSetVsrClient: (
     wallet: SignerWalletAdapter | undefined,
@@ -86,6 +87,7 @@ const defaultState = {
     realm: undefined,
     walletPk: undefined,
   }),
+  maxVoterWeight: undefined,
 }
 
 const useVotePluginsClientStore = create<UseVotePluginsClientStore>(
@@ -192,8 +194,16 @@ const useVotePluginsClientStore = create<UseVotePluginsClientStore>(
             provider,
             connection.cluster
           )
+
+          const maxVoterWeight = (
+            await pythClient.stakeConnection.program.methods
+              .updateMaxVoterWeight()
+              .pubkeys()
+          ).maxVoterRecord
+
           set((s) => {
             s.state.pythClient = pythClient
+            s.state.maxVoterWeight = maxVoterWeight
           })
         } catch (e) {
           console.error(e)


### PR DESCRIPTION
Currently the `maxVoterWeight` plugin can't be used for finalizing proposals unless one is using the Nft Voter Plugin. I'm trying to fix that.

The implementation for the NftPlugin relies on `maxVoterWeight`, stored in the `nftPluginStore`. However for generic voter weight plugins, it makes more sense to store it in `UseVotePluginsClientStore` as more plugins might benefit from accessing this field.

This is exactly what we do here, we introduce a new field `maxVoterWeight: PublicKey | undefined` that each `VotingClient` can populate and use.

Alternative designs are welcome!