### PR TITLE
Agrippa/show-plugin-pubkeys

### DIFF
--- a/components/treasuryV2/Details/RealmAuthorityDetails/Config.tsx
+++ b/components/treasuryV2/Details/RealmAuthorityDetails/Config.tsx
@@ -17,6 +17,7 @@ import { formatNumber } from '@utils/formatNumber'
 import { DISABLED_VOTER_WEIGHT } from '@tools/constants'
 import useRealm from '@hooks/useRealm'
 import Section from '../Section'
+import Address from '@components/Address'
 
 const DISABLED = new BigNumber(DISABLED_VOTER_WEIGHT.toString())
 
@@ -58,16 +59,40 @@ export default function Config(props: Props) {
     {
       icon: <BeakerIcon />,
       title: 'Use community voter weight add-in',
-      value: props.realmAuthority.config.useCommunityVoterWeightAddin
-        ? 'Yes'
-        : 'No',
+      value: props.realmAuthority.config.useCommunityVoterWeightAddin ? (
+        <div className="flex gap-x-2">
+          Yes
+          <span className="text-white/50 flex-nowrap flex">
+            (
+            <Address
+              address={props.realmAuthority.config.useCommunityVoterWeightAddin}
+            />
+            )
+          </span>
+        </div>
+      ) : (
+        'No'
+      ),
     },
     {
       icon: <BeakerIcon />,
       title: 'Use max community voter weight add-in',
-      value: props.realmAuthority.config.useMaxCommunityVoterWeightAddin
-        ? 'Yes'
-        : 'No',
+      value: props.realmAuthority.config.useMaxCommunityVoterWeightAddin ? (
+        <div className="flex gap-x-2">
+          Yes
+          <span className="text-white/50 flex-nowrap flex">
+            (
+            <Address
+              address={
+                props.realmAuthority.config.useMaxCommunityVoterWeightAddin
+              }
+            />
+            )
+          </span>
+        </div>
+      ) : (
+        'No'
+      ),
     },
   ]
 

--- a/components/treasuryV2/Details/Section.tsx
+++ b/components/treasuryV2/Details/Section.tsx
@@ -5,7 +5,7 @@ interface Props {
   className?: string
   icon: JSX.Element
   name: string
-  value: string
+  value: JSX.Element | string
 }
 
 export default function Section(props: Props) {

--- a/hooks/useTreasuryInfo/assembleWallets.tsx
+++ b/hooks/useTreasuryInfo/assembleWallets.tsx
@@ -279,10 +279,12 @@ export const assembleWallets = async (
             minCommunityTokensToCreateGovernance: new BigNumber(
               config.minCommunityTokensToCreateGovernance.toString()
             ).shiftedBy(communityMint ? -communityMint.decimals : 0),
-            useCommunityVoterWeightAddin: !!realmConfig?.account
-              .communityTokenConfig.voterWeightAddin,
-            useMaxCommunityVoterWeightAddin: !!realmConfig?.account
-              .communityTokenConfig.maxVoterWeightAddin,
+            useCommunityVoterWeightAddin:
+              realmConfig?.account.communityTokenConfig.voterWeightAddin ??
+              false,
+            useMaxCommunityVoterWeightAddin:
+              realmConfig?.account.communityTokenConfig.maxVoterWeightAddin ??
+              false,
           },
           icon: realmInfo?.ogImage ? (
             <img src={realmInfo.ogImage} />

--- a/models/treasury/Asset.ts
+++ b/models/treasury/Asset.ts
@@ -5,6 +5,7 @@ import type { AssetAccount } from '@utils/uiTypes/assets'
 
 import { NFT } from './NFT'
 import { Program } from './Program'
+import { PublicKey } from '@solana/web3.js'
 
 export enum AssetType {
   Mint,
@@ -52,8 +53,8 @@ export interface RealmAuthority {
   config: {
     communityMintMaxVoteWeightSource?: MintMaxVoteWeightSource
     minCommunityTokensToCreateGovernance: BigNumber
-    useCommunityVoterWeightAddin?: boolean
-    useMaxCommunityVoterWeightAddin?: boolean
+    useCommunityVoterWeightAddin?: PublicKey | false
+    useMaxCommunityVoterWeightAddin?: PublicKey | false
   }
   icon: JSX.Element
   name: string


### PR DESCRIPTION
This PR makes the pubkey of plugins visible when viewing configuration. 

Using http://localhost:3000/dao/CWDxX9e24TR8KHAPWB1Xu2xaNwqcBACmQeuQX2PLuaub/treasury/v2?cluster=devnet as an example:
<img width="993" alt="image" src="https://user-images.githubusercontent.com/12001874/190006787-f311a19d-e487-43a0-b556-f3a695b5bbe9.png">

(Previously it just said "Yes").