### PR TITLE
Reduce husky workload by >90%

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,4 @@
 #!/bin/sh
 . "$(dirname "$0")/_/husky.sh"
 
-yarn lint-staged && yarn type-check && yarn lint
+yarn lint-staged && yarn lint

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,4 +1,4 @@
 #!/bin/sh
 . "$(dirname "$0")/_/husky.sh"
 
-yarn lint-staged && yarn lint
+yarn lint-staged


### PR DESCRIPTION
Profiling on my new-but-pre-M1 Macbook:
<img width="418" alt="image" src="https://user-images.githubusercontent.com/12001874/190012935-fb46d483-4312-445f-aa1c-c5e494c24d4e.png">

Type-check after each commit seems unnecessary given that Vercel does this for us. Likewise linting the entire repo seems overkill as opposed to lint-staged. 

It's possible I would just get rid of Husky entirely, and use a bot for style compliance, but this PR seems like a strict improvement.

(I did test and it appears to work. As an aside, lint-staged can be surprisingly slow.)