### PR TITLE
add skip script from vercel examples

### DIFF
--- a/scripts/skip-vercel-builds.sh
+++ b/scripts/skip-vercel-builds.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+# copied from https://vercel.com/guides/how-do-i-use-the-ignored-build-step-field-on-vercel
+
+echo "VERCEL_ENV: $VERCEL_ENV"
+
+if [[ "$VERCEL_ENV" == "production" ]] ; then
+  # Proceed with the build
+  echo "✅ - Build can proceed"
+  exit 1;
+
+else
+  # Don't build
+  echo "🛑 - Build cancelled"
+  exit 0;
+fi


### PR DESCRIPTION
This is for usage in blockworks vercel config, for skipping preview deploys.