### PR TITLE
nft holaplex indexer only if mainnet cluster

### DIFF
--- a/utils/tokens.tsx
+++ b/utils/tokens.tsx
@@ -420,10 +420,10 @@ export const getNfts = async (
   ownerPk: PublicKey,
   connection: ConnectionContext
 ): Promise<NFTWithMeta[]> => {
-  if (connection.cluster === 'devnet') {
-    return await getDevnetNfts(ownerPk, connection.current)
-  } else {
+  if (connection.cluster === 'mainnet') {
     return await getMainnetNfts(ownerPk, connection.current)
+  } else {
+    return await getDevnetNfts(ownerPk, connection.current)
   }
 }
 


### PR DESCRIPTION
**Problem**
user/treasury nfts are not displayed if cluster is localhost


**Solution**
only fetch from holaplex if cluster is mainnet