### PR TITLE
Realm hub, Integrate Jupiter header token price, Jupiter direct link

### DIFF
--- a/hub/components/HeaderTokenPrice/index.tsx
+++ b/hub/components/HeaderTokenPrice/index.tsx
@@ -20,15 +20,20 @@ function useTokenPrice(symbol: string, mint: PublicKey) {
     if (typeof window !== 'undefined') {
       setResult(RE.pending());
 
-      setTimeout(() => {
-        setResult(
-          RE.ok({
-            direction: 'up',
-            percentChange: 59.8,
-            price: 0.345132,
-          }),
-        );
-      }, 1000);
+      const mintAddress = mint.toString();
+      fetch(`https://price.jup.ag/v3/price?ids=${mintAddress}`)
+        .then((resp) => resp.json())
+        .then((result) => {
+          const price = result.data[mintAddress].price || 0;
+
+          setResult(
+            RE.ok({
+              direction: 'up',
+              percentChange: 0,
+              price,
+            }),
+          );
+        });
     }
   }, [symbol]);
 
@@ -81,25 +86,30 @@ export function HeaderTokenPrice(props: Props) {
             <div className="text-xs text-neutral-600">
               #{props.symbol} Price
             </div>
-            <CautionIcon
-              className={cx(
-                'h-2',
-                'mx-[1px]',
-                'w-2',
-                direction === 'up' && 'fill-emerald-500',
-                direction === 'down' && 'fill-rose-500',
-                direction === 'down' && 'rotate-180',
-              )}
-            />
-            <div
-              className={cx(
-                'text-xs',
-                direction === 'up' && 'text-emerald-500',
-                direction === 'down' && 'text-rose-500',
-              )}
-            >
-              {percentChange}%
-            </div>
+            {percentChange !== 0 ? (
+              <CautionIcon
+                className={cx(
+                  'h-2',
+                  'mx-[1px]',
+                  'w-2',
+                  direction === 'up' && 'fill-emerald-500',
+                  direction === 'down' && 'fill-rose-500',
+                  direction === 'down' && 'rotate-180',
+                )}
+              />
+            ) : null}
+
+            {percentChange !== 0 ? (
+              <div
+                className={cx(
+                  'text-xs',
+                  direction === 'up' && 'text-emerald-500',
+                  direction === 'down' && 'text-rose-500',
+                )}
+              >
+                {percentChange}%
+              </div>
+            ) : null}
           </div>
           <div className="text-lg text-neutral-900">${price}</div>
         </div>

--- a/hub/components/RealmHeader/index.tsx
+++ b/hub/components/RealmHeader/index.tsx
@@ -5,14 +5,15 @@ import LogoDiscord from '@carbon/icons-react/lib/LogoDiscord';
 import LogoGithub from '@carbon/icons-react/lib/LogoGithub';
 import LogoInstagram from '@carbon/icons-react/lib/LogoInstagram';
 import LogoLinkedin from '@carbon/icons-react/lib/LogoLinkedin';
-// import ProgressBarRound from '@carbon/icons-react/lib/ProgressBarRound';
+import ProgressBarRound from '@carbon/icons-react/lib/ProgressBarRound';
 // import UserFollow from '@carbon/icons-react/lib/UserFollow';
 import WalletIcon from '@carbon/icons-react/lib/Wallet';
 import * as NavigationMenu from '@radix-ui/react-navigation-menu';
 import type { PublicKey } from '@solana/web3.js';
+import { useMemo } from 'react';
 
 import * as Button from '@hub/components/controls/Button';
-// import { HeaderTokenPrice } from '@hub/components/HeaderTokenPrice';
+import { HeaderTokenPrice } from '@hub/components/HeaderTokenPrice';
 import { Twitter } from '@hub/components/icons/Twitter';
 import * as RealmBanner from '@hub/components/RealmBanner';
 import * as RealmHeaderIcon from '@hub/components/RealmHeaderIcon';
@@ -47,6 +48,13 @@ interface Props extends BaseProps {
 }
 
 export function Content(props: Props) {
+  const jupiterDirectLink = useMemo(() => {
+    if (props.token?.mint) {
+      return `https://jup.ag/swap/USDC-${props.token?.mint.toString()}?inAmount=1`;
+    }
+    return 'https://jup.ag';
+  }, [props.token]);
+
   return (
     <header className={cx(props.className, 'bg-white')}>
       <RealmBanner.Content bannerUrl={props.bannerUrl} realm={props.realm} />
@@ -63,29 +71,26 @@ export function Content(props: Props) {
             </div>
           </div>
           <div className="flex items-center">
-            {/* {props.token && (
+            {props.token && (
               <div className="mr-8">
                 <HeaderTokenPrice
                   mint={props.token.mint}
                   symbol={props.token.symbol}
                 />
               </div>
-            )} */}
+            )}
             {/* <Button.Secondary className="w-36">
               <UserFollow className="h-4 w-4 mr-1.5" />
               Follow
             </Button.Secondary> */}
-            {/* {props.token && (
-              <Button.Primary
-                className="w-36 text-white ml-2"
-                onClick={() => {
-                  const { mint, symbol } = props.token;
-                }}
-              >
-                <ProgressBarRound className="h-4 w-4 mr-1.5" />
-                Buy #{props.token.symbol}
-              </Button.Primary>
-            )} */}
+            {props.token && (
+              <a href={jupiterDirectLink} target="_blank">
+                <Button.Primary className="w-36 text-white ml-2">
+                  <ProgressBarRound className="h-4 w-4 mr-1.5" />
+                  Buy #{props.token.symbol}
+                </Button.Primary>
+              </a>
+            )}
           </div>
         </div>
         <div className="mt-6 flex items-center justify-between px-2">

--- a/pages/realm/[id]/hub/index.tsx
+++ b/pages/realm/[id]/hub/index.tsx
@@ -8,23 +8,29 @@ import devnetList from 'public/realms/devnet.json'
 
 import { Hub } from '@hub/components/Hub'
 import { ECOSYSTEM_PAGE } from '@hub/lib/constants'
+import useWalletStore from 'stores/useWalletStore'
 
 export default function RealmAbout() {
   const router = useRouter()
+  const { connection } = useWalletStore()
   const { id } = router.query
 
   let publicKey: PublicKey | null = null
 
   if (typeof id === 'string') {
-    for (const item of mainnetList) {
-      if (item.symbol.toLowerCase() === id.toLowerCase()) {
-        publicKey = new PublicKey(item.realmId)
+    if (connection.cluster === 'mainnet') {
+      for (const item of mainnetList) {
+        if (item.symbol.toLowerCase() === id.toLowerCase()) {
+          publicKey = new PublicKey(item.realmId)
+        }
       }
     }
 
-    for (const item of devnetList) {
-      if (item.symbol.toLowerCase() === id.toLowerCase()) {
-        publicKey = new PublicKey(item.realmId)
+    if (connection.cluster === 'devnet') {
+      for (const item of devnetList) {
+        if (item.symbol.toLowerCase() === id.toLowerCase()) {
+          publicKey = new PublicKey(item.realmId)
+        }
       }
     }
 


### PR DESCRIPTION
Realm hub
- URL to test `http://localhost:3000/realm/Metaplex/hub`
- Integrate Jupiter Price API to show token price (without historical price support yet)
- Integrate an anchor link that redirects to Jupiter to purchase relevant token to the DAOs, as long as getHub query provides it. 

```ts
const [result] = useQuery(gql.getHubResp, {
    query: gql.getHub,
    variables: { realm: props.realm.toBase58() },
  });
```

Side note:
Another PR is in progress that integrates Jupiter within the app instead of anchor link.