### PR TITLE
Fix token count overflow & displayed council delegated token count

### DIFF
--- a/components/TokenBalance/DelegateTokenBalanceCard.tsx
+++ b/components/TokenBalance/DelegateTokenBalanceCard.tsx
@@ -1,11 +1,11 @@
+import { useEffect } from 'react'
+import { BN_ZERO } from '@solana/spl-governance'
+import { DisplayAddress } from '@cardinal/namespaces-components'
+import Select from '@components/inputs/Select'
+import { fmtMintAmount } from '@tools/sdk/units'
 import useMembersStore from 'stores/useMembersStore'
 import useWalletStore from 'stores/useWalletStore'
-import Select from '@components/inputs/Select'
 import useRealm from 'hooks/useRealm'
-import { DisplayAddress } from '@cardinal/namespaces-components'
-import { fmtMintAmount } from '@tools/sdk/units'
-import { BN } from '@project-serum/anchor'
-import { useEffect } from 'react'
 
 const DelegateBalanceCard = () => {
   const delegates = useMembersStore((s) => s.compact.delegates)
@@ -56,17 +56,17 @@ const DelegateBalanceCard = () => {
 
   const getCouncilTokenCount = () => {
     if (walletId && delegates?.[walletId]) {
-      return delegates?.[walletId].councilTokenCount || 0
+      return fmtMintAmount(
+        councilMint,
+        delegates?.[walletId].councilTokenCount ?? BN_ZERO
+      )
     }
     return 0
   }
 
   const getCouncilDelegateAmt = () => {
     if (walletId && delegates?.[walletId]) {
-      return fmtMintAmount(
-        councilMint,
-        new BN(delegates?.[walletId].councilTokenCount || 0)
-      )
+      return delegates?.[walletId]?.councilMembers?.length ?? 0
     }
     return 0
   }
@@ -75,7 +75,7 @@ const DelegateBalanceCard = () => {
     if (walletId && delegates?.[walletId]) {
       return fmtMintAmount(
         mint,
-        new BN(delegates?.[walletId].communityTokenCount || 0)
+        delegates?.[walletId].communityTokenCount ?? BN_ZERO
       )
     }
     return 0
@@ -83,7 +83,7 @@ const DelegateBalanceCard = () => {
 
   const getCommunityDelegateAmt = () => {
     if (walletId && delegates?.[walletId]) {
-      return delegates?.[walletId]?.communityMembers?.length || 0
+      return delegates?.[walletId]?.communityMembers?.length ?? 0
     }
     return 0
   }

--- a/utils/uiTypes/members.ts
+++ b/utils/uiTypes/members.ts
@@ -15,8 +15,8 @@ export interface Member {
 export interface Delegate {
   communityMembers?: Array<Member>
   councilMembers?: Array<Member>
-  communityTokenCount?: number
-  councilTokenCount?: number
+  communityTokenCount?: BN
+  councilTokenCount?: BN
 }
 
 export interface Delegates {


### PR DESCRIPTION
Makes `communityTokenCount` and `councilTokenCount` BN to avoid overflow.

It may happens when manipulating 9 decimals tokens.

```
bn.js:6 Uncaught (in promise) Error: Number can only safely store up to 53 bits
    at r (bn.js:6:21)
    at i.toNumber (bn.js:547:7)
    at useMembers.tsx:257:39
    at Array.forEach (<anonymous>)
    at k (useMembers.tsx:217:13)
    at useMembers.tsx:281:27
    at s (runtime.js:45:40)
    at Generator._invoke (runtime.js:274:22)
    at forEach.e.<computed> [as next] (runtime.js:97:21)
    at r (asyncToGenerator.js:3:20)
    at a (asyncToGenerator.js:25:9)
    at asyncToGenerator.js:32:7
    at new Promise (<anonymous>)
    at asyncToGenerator.js:21:12
    at useMembers.tsx:279:23
    at useMembers.tsx:291:7
    at Yu (react-dom.production.min.js:241:332)
    at fs (react-dom.production.min.js:285:111)
    at Gi (react-dom.production.min.js:272:185)
    at Vl (react-dom.production.min.js:127:105)
    at react-dom.production.min.js:282:404
    at cs (react-dom.production.min.js:280:396)
    at qi (react-dom.production.min.js:270:253)
    at S (scheduler.production.min.js:13:203)
    at MessagePort.T (scheduler.production.min.js:14:128)
```

To reproduce, go on https://app.realms.today/dao/UXP and open the console.

This PR also include a fix about displaying delegated council token amount (found it when changing the file).

Show 2 delegated accounts instead of 1:
<img width="792" alt="Screenshot 2022-11-03 at 17 22 56" src="https://user-images.githubusercontent.com/22965416/199732361-7634e9c8-75db-429e-89b0-360a82202a2a.png">


Finally some syntax nit.