### PR TITLE
Revert commit changes breaking the vesting creation from governed accounts

### DIFF
--- a/components/instructions/programs/streamflow.tsx
+++ b/components/instructions/programs/streamflow.tsx
@@ -123,6 +123,90 @@ export const MINT_METADATA = {
   Gssm3vfi8s65R31SBdmQRq6cKeYojGgup7whkw4VCiQj: { symbol: 'STRM', decimals: 9 },
 }
 
+async function getStreamCreateDataUI(
+  connection: Connection,
+  data: Uint8Array,
+  accounts: AccountMetaData[]
+) {
+  try {
+    const cli = new StreamClient(
+      connection.rpcEndpoint,
+      Cluster.Devnet, //add option to client to attach connection
+      undefined,
+      accounts[0].pubkey.toBase58()
+    )
+
+    const hasExplicitPayer = accounts.length === 12
+    const metadataIndex = hasExplicitPayer ? 3 : 2
+    const mintIndex = hasExplicitPayer ? 6 : 5
+
+    const contractMetadata = accounts[metadataIndex].pubkey
+    const mint = accounts[mintIndex].pubkey
+    const stream = await cli.getOne(contractMetadata.toBase58())
+    const isExecuted = stream.createdAt > 0
+    const mintMetadata = getMintMetadata(mint)
+    const decimals = mintMetadata.decimals
+    const streamData = deserStream(data, stream, decimals)
+    const withdrawn = getNumberFromBN(stream.withdrawnAmount, decimals)
+    const unlockedPercent = Math.round(
+      (withdrawn / streamData.amountDeposited) * 100
+    )
+
+    return (
+      <div>
+        <div>
+          <span>Start:</span>
+          {streamData.start == 0 && ' On approval '}
+          {streamData.start > 0 && (
+            <span> {new Date(streamData.start * 1000).toISOString()} UTC</span>
+          )}
+        </div>
+
+        <div>
+          <span>Amount:</span>
+          <span>
+            {' '}
+            {streamData.amountDeposited} {mintMetadata.symbol}
+          </span>
+        </div>
+        <div>
+          <span>Unlocked every:</span>
+          <span> {formatPeriodOfTime(streamData.releaseFrequency)}</span>
+        </div>
+        <div>
+          <span>Release amount:</span>
+          <span>
+            {' '}
+            {streamData.releaseAmount} {mintMetadata.symbol}
+          </span>
+        </div>
+        <div>
+          <span>Released at start:</span>
+          <span> {streamData.amountAtCliff}</span>
+        </div>
+        <div>
+          <span>Contract is cancelable:</span>
+          <span> {streamData.cancelable ? 'Yes' : 'No'}</span>
+        </div>
+        <br></br>
+        {isExecuted && (
+          <div>
+            <span>Unlocked: {unlockedPercent}%</span>
+            <VoteResultsBar
+              approveVotePercentage={unlockedPercent}
+              denyVotePercentage={0}
+            />
+            <br></br>
+          </div>
+        )}
+      </div>
+    )
+  } catch (error) {
+    console.log(error)
+    return <></>
+  }
+}
+
 export function getMintMetadata(
   tokenMintPk: PublicKey | undefined
 ): TokenMintMetadata {
@@ -141,6 +225,24 @@ export function getMintMetadata(
 
 export const STREAMFLOW_INSTRUCTIONS = {
   strmRqUCoQUgGUan5YhzUZa6KqdzwX5L6FpUxfmKg5m: {
+    0: {
+      name: 'Streamflow: Create',
+      accounts: [
+        { name: 'Payer treasury', important: true },
+        { name: 'Governed treasury', important: true },
+        { name: 'Token treasury', important: true },
+        { name: 'Contract metadata' },
+        { name: 'PDA Token account' },
+        { name: 'Liquidator' },
+        { name: 'Mint' },
+        { name: 'Streamflow treasury' },
+        { name: 'Rent' },
+        { name: 'Streamflow program' },
+        { name: 'Token program' },
+        { name: 'System program' },
+      ],
+      getDataUI: getStreamCreateDataUI,
+    },
     174: {
       name: 'Streamflow: Create',
       accounts: [
@@ -156,92 +258,7 @@ export const STREAMFLOW_INSTRUCTIONS = {
         { name: 'Token program' },
         { name: 'System program' },
       ],
-      getDataUI: async (
-        connection: Connection,
-        data: Uint8Array,
-        accounts: AccountMetaData[]
-      ) => {
-        try {
-          const cli = new StreamClient(
-            connection.rpcEndpoint,
-            Cluster.Devnet, //add option to client to attach connection
-            undefined,
-            accounts[0].pubkey.toBase58()
-          )
-
-          const hasExplicitPayer = accounts.length === 12
-          const metadataIndex = hasExplicitPayer ? 3 : 2
-          const mintIndex = hasExplicitPayer ? 6 : 5
-
-          const contractMetadata = accounts[metadataIndex].pubkey
-          const mint = accounts[mintIndex].pubkey
-          const stream = await cli.getOne(contractMetadata.toBase58())
-          const isExecuted = stream.createdAt > 0
-          const mintMetadata = getMintMetadata(mint)
-          const decimals = mintMetadata.decimals
-          const streamData = deserStream(data, stream, decimals)
-          const withdrawn = getNumberFromBN(stream.withdrawnAmount, decimals)
-          const unlockedPercent = Math.round(
-            (withdrawn / streamData.amountDeposited) * 100
-          )
-
-          return (
-            <div>
-              <div>
-                <span>Start:</span>
-                {streamData.start == 0 && ' On approval '}
-                {streamData.start > 0 && (
-                  <span>
-                    {' '}
-                    {new Date(streamData.start * 1000).toISOString()} UTC
-                  </span>
-                )}
-              </div>
-
-              <div>
-                <span>Amount:</span>
-                <span>
-                  {' '}
-                  {streamData.amountDeposited} {mintMetadata.symbol}
-                </span>
-              </div>
-              <div>
-                <span>Unlocked every:</span>
-                <span> {formatPeriodOfTime(streamData.releaseFrequency)}</span>
-              </div>
-              <div>
-                <span>Release amount:</span>
-                <span>
-                  {' '}
-                  {streamData.releaseAmount} {mintMetadata.symbol}
-                </span>
-              </div>
-              <div>
-                <span>Released at start:</span>
-                <span> {streamData.amountAtCliff}</span>
-              </div>
-              <div>
-                <span>Contract is cancelable:</span>
-                <span> {streamData.cancelable ? 'Yes' : 'No'}</span>
-              </div>
-              <br></br>
-              {isExecuted && (
-                <div>
-                  <span>Unlocked: {unlockedPercent}%</span>
-                  <VoteResultsBar
-                    approveVotePercentage={unlockedPercent}
-                    denyVotePercentage={0}
-                  />
-                  <br></br>
-                </div>
-              )}
-            </div>
-          )
-        } catch (error) {
-          console.log(error)
-          return <></>
-        }
-      },
+      getDataUI: getStreamCreateDataUI,
     },
     232: {
       name: 'Streamflow: Cancel',


### PR DESCRIPTION
**Issue:** Some DAO owned token accounts are owned by data carrying PDAs, Solana doesn't allow data carrying PDA to create account and/or do lamport transfers witch is essential for Streamflow vesting creation.
This PR https://github.com/solana-labs/governance-ui/pull/1184 by @sjillen did some cleanups, but removed support for separate payer as well. Which breaks UI view for Some vesting contracts, and disallow Governed token accounts to create Vesting contracts.

**Solution**: Reverted back my changes, left changes introduced by  intact.