### PR TITLE
feat: domains view in Wallets & Assets Page

### DIFF
--- a/components/DropdownMenu/DropdownMenu.tsx
+++ b/components/DropdownMenu/DropdownMenu.tsx
@@ -21,10 +21,14 @@ const DropdownMenu: React.FC<Props> = (props) => {
         side="top"
         sideOffset={5}
       >
-       {(Array.isArray(props.children) ? props.children : [props.children])
+        {(Array.isArray(props.children) ? props.children : [props.children])
           .filter((menuItem) => menuItem)
-          .map((menuItem: React.ReactNode, index: number) => (
-            <Dropdown.Item className="DropdownMenuItem" key={menuItem.toString()}>
+          .map((menuItem: React.ReactNode) => (
+            <Dropdown.Item
+              className="DropdownMenuItem"
+              // menu item will exist because of the filter above.
+              key={menuItem!.toString()}
+            >
               {menuItem}
             </Dropdown.Item>
           ))}

--- a/components/DropdownMenu/DropdownMenu.tsx
+++ b/components/DropdownMenu/DropdownMenu.tsx
@@ -1,0 +1,46 @@
+import React from 'react'
+import * as Dropdown from '@radix-ui/react-dropdown-menu'
+import { DotsVerticalIcon } from '@heroicons/react/solid'
+
+interface Props {
+  triggerButton: React.ReactNode
+  children: React.ReactNode[] | React.ReactNode
+}
+
+const DropdownMenu: React.FC<Props> = (props) => {
+  return (
+    <Dropdown.Root>
+      <Dropdown.Trigger asChild>
+        <button aria-label="Further Options">
+          <DotsVerticalIcon className=" h-4 w-4" />
+        </button>
+      </Dropdown.Trigger>
+
+      <Dropdown.Content
+        className="DropdownMenuContent"
+        side="top"
+        sideOffset={5}
+      >
+        {Array.isArray(props.children) ? (
+          props.children?.map((menuItem: React.ReactNode) => (
+            <Dropdown.Item
+              className="DropdownMenuItem"
+              key={menuItem?.toString()}
+            >
+              {menuItem}
+            </Dropdown.Item>
+          ))
+        ) : (
+          <Dropdown.Item
+            className="DropdownMenuItem"
+            key={props.children?.toString()}
+          >
+            {props.children}
+          </Dropdown.Item>
+        )}
+      </Dropdown.Content>
+    </Dropdown.Root>
+  )
+}
+
+export default DropdownMenu

--- a/components/DropdownMenu/DropdownMenu.tsx
+++ b/components/DropdownMenu/DropdownMenu.tsx
@@ -12,7 +12,7 @@ const DropdownMenu: React.FC<Props> = (props) => {
     <Dropdown.Root>
       <Dropdown.Trigger asChild>
         <button aria-label="Further Options">
-          <DotsVerticalIcon className=" h-4 w-4" />
+          <DotsVerticalIcon className="h-4 w-4" />
         </button>
       </Dropdown.Trigger>
 
@@ -21,23 +21,13 @@ const DropdownMenu: React.FC<Props> = (props) => {
         side="top"
         sideOffset={5}
       >
-        {Array.isArray(props.children) ? (
-          props.children?.map((menuItem: React.ReactNode) => (
-            <Dropdown.Item
-              className="DropdownMenuItem"
-              key={menuItem?.toString()}
-            >
+       {(Array.isArray(props.children) ? props.children : [props.children])
+          .filter((menuItem) => menuItem)
+          .map((menuItem: React.ReactNode, index: number) => (
+            <Dropdown.Item className="DropdownMenuItem" key={menuItem.toString()}>
               {menuItem}
             </Dropdown.Item>
-          ))
-        ) : (
-          <Dropdown.Item
-            className="DropdownMenuItem"
-            key={props.children?.toString()}
-          >
-            {props.children}
-          </Dropdown.Item>
-        )}
+          ))}
       </Dropdown.Content>
     </Dropdown.Root>
   )

--- a/components/DropdownMenu/index.css
+++ b/components/DropdownMenu/index.css
@@ -1,0 +1,83 @@
+.DropdownMenuContent {
+  min-width: 220px;
+  background-color: rgba(0, 0, 0);
+  padding: 0.5rem 5px;
+  z-index: 20;
+  border-radius: 4px;
+  box-shadow: 0px 10px 38px -10px rgba(22, 23, 24, 0.35),
+    0px 10px 20px -15px rgba(22, 23, 24, 0.2);
+  animation-duration: 400ms;
+  animation-timing-function: cubic-bezier(0.16, 1, 0.3, 1);
+  will-change: transform, opacity;
+}
+.DropdownMenuContent[data-side='top'] {
+  animation-name: slideDownAndFade;
+}
+.DropdownMenuContent[data-side='right'] {
+  animation-name: slideLeftAndFade;
+}
+.DropdownMenuContent[data-side='bottom'] {
+  animation-name: slideUpAndFade;
+}
+.DropdownMenuContent[data-side='left'] {
+  animation-name: slideRightAndFade;
+}
+
+.DropdownMenuItem {
+  font-size: 13px;
+  line-height: 1;
+  color: var(--violet11);
+  border-radius: 3px;
+  display: flex;
+  align-items: center;
+  height: 25px;
+  padding: 1rem 0.25rem;
+  position: relative;
+  padding-left: 25px;
+  user-select: none;
+  outline: none;
+}
+
+@keyframes slideUpAndFade {
+  from {
+    opacity: 0;
+    transform: translateY(2px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@keyframes slideRightAndFade {
+  from {
+    opacity: 0;
+    transform: translateX(-2px);
+  }
+  to {
+    opacity: 1;
+    transform: translateX(0);
+  }
+}
+
+@keyframes slideDownAndFade {
+  from {
+    opacity: 0;
+    transform: translateY(-2px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+@keyframes slideLeftAndFade {
+  from {
+    opacity: 0;
+    transform: translateX(2px);
+  }
+  to {
+    opacity: 1;
+    transform: translateX(0);
+  }
+}

--- a/components/treasuryV2/Details/DomainsDetails/Header.tsx
+++ b/components/treasuryV2/Details/DomainsDetails/Header.tsx
@@ -1,0 +1,42 @@
+import React from 'react'
+import cx from 'classnames'
+import { GlobeIcon } from '@heroicons/react/outline'
+
+import { formatNumber } from '@utils/formatNumber'
+import { Domains } from '@models/treasury/Asset'
+
+interface Props {
+  className?: string
+  domains: Domains
+}
+
+export default function Header(props: Props) {
+  return (
+    <div
+      className={cx(
+        props.className,
+        'bg-bkg-1',
+        'min-h-[128px]',
+        'px-8',
+        'py-4',
+        'flex',
+        'items-center',
+        'justify-between'
+      )}
+    >
+      <div>
+        <div className="flex items-center space-x-4">
+          <div className="flex items-center justify-center h-10 w-10 rounded-full bg-white/20">
+            <GlobeIcon className="h-6 w-6 stroke-primary-light" />
+          </div>
+          <div>
+            <div className="text-white/50 text-sm">Domains in this wallet</div>
+            <div className="text-fgd-1 font-bold text-2xl">
+              {formatNumber(props.domains.count, undefined, {})}
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/components/treasuryV2/Details/DomainsDetails/Info/Domain.tsx
+++ b/components/treasuryV2/Details/DomainsDetails/Info/Domain.tsx
@@ -1,0 +1,110 @@
+import React from 'react'
+import Link from 'next/link'
+import cx from 'classnames'
+
+import { ExternalLinkIcon, DotsVerticalIcon } from '@heroicons/react/outline'
+import { ArrowsHorizontal } from '@carbon/icons-react'
+
+import DropdownMenu from '@components/DropdownMenu/DropdownMenu'
+import Tooltip from '@components/Tooltip'
+
+import useRealm from '@hooks/useRealm'
+import useQueryContext from '@hooks/useQueryContext'
+import useWalletStore from 'stores/useWalletStore'
+
+import { Domain as DomainModel } from '@models/treasury/Domain'
+
+interface Props {
+  domain: DomainModel
+}
+
+const Domain: React.FC<Props> = (props) => {
+  const { fmtUrlWithCluster } = useQueryContext()
+  const connected = useWalletStore((s) => s.connected)
+  const {
+    symbol,
+    realm,
+    governances,
+    ownVoterWeight,
+    toManyCommunityOutstandingProposalsForUser,
+    toManyCouncilOutstandingProposalsForUse,
+  } = useRealm()
+
+  const governanceItems = Object.values(governances)
+
+  const canCreateProposal =
+    realm &&
+    governanceItems.some((g) =>
+      ownVoterWeight.canCreateProposal(g.account.config)
+    ) &&
+    !toManyCommunityOutstandingProposalsForUser &&
+    !toManyCouncilOutstandingProposalsForUse
+
+  const tooltipContent = !connected
+    ? 'Connect your wallet to create new proposal'
+    : governanceItems.length === 0
+    ? 'There is no governance configuration to create a new proposal'
+    : !governanceItems.some((g) =>
+        ownVoterWeight.canCreateProposal(g.account.config)
+      )
+    ? "You don't have enough governance power to create a new proposal"
+    : toManyCommunityOutstandingProposalsForUser
+    ? 'Too many community outstanding proposals. You need to finalize them before creating a new one.'
+    : toManyCouncilOutstandingProposalsForUse
+    ? 'Too many council outstanding proposals. You need to finalize them before creating a new one.'
+    : ''
+
+  return (
+    <div className="flex justify-between items-center px-2 py-6 border-b-[0.5px] border-white/50">
+      <span className="block text-base font-medium">
+        {props.domain.name + '.sol'}
+      </span>
+      <div className="flex gap-4 ">
+        <Link
+          href={`https://explorer.solana.com/address/${props.domain.address}`}
+        >
+          <a
+            target="_blank"
+            rel="noreferrer"
+            className={cx(
+              'text-primary-light',
+              'transition-all',
+              'flex',
+              'text-xs',
+              'items-center',
+              'gap-1'
+            )}
+          >
+            <ExternalLinkIcon className="h-3 w-3" />
+            Visit
+          </a>
+        </Link>
+        <DropdownMenu
+          triggerButton={
+            <button aria-label="Further Options">
+              <DotsVerticalIcon className=" h-4 w-4" />
+            </button>
+          }
+        >
+          <Tooltip content={tooltipContent}>
+            <div className={cx(!canCreateProposal ? 'cursor-not-allowed' : '')}>
+              <Link href={fmtUrlWithCluster(`/dao/${symbol}/proposal/new`)}>
+                <a
+                  className={cx(
+                    !canCreateProposal ? 'pointer-events-none' : '',
+                    'flex items-center text-fgd-3 hover:text-fgd-2 gap-2 text-sm'
+                  )}
+                >
+                  <ArrowsHorizontal className="h-4 w-4" />
+                  Transfer Domain
+                </a>
+              </Link>
+            </div>
+          </Tooltip>
+        </DropdownMenu>
+      </div>
+    </div>
+  )
+}
+
+export default Domain

--- a/components/treasuryV2/Details/DomainsDetails/Info/Domain.tsx
+++ b/components/treasuryV2/Details/DomainsDetails/Info/Domain.tsx
@@ -57,7 +57,7 @@ const Domain: React.FC<Props> = (props) => {
   return (
     <div className="flex justify-between items-center px-2 py-6 border-b-[0.5px] border-white/50">
       <span className="block text-base font-medium">
-        {props.domain.name + '.sol'}
+        {`${props.domain.name}.sol`}
       </span>
       <div className="flex gap-4 ">
         <Link
@@ -82,7 +82,7 @@ const Domain: React.FC<Props> = (props) => {
         <DropdownMenu
           triggerButton={
             <button aria-label="Further Options">
-              <DotsVerticalIcon className=" h-4 w-4" />
+              <DotsVerticalIcon className="h-4 w-4" />
             </button>
           }
         >

--- a/components/treasuryV2/Details/DomainsDetails/Info/index.tsx
+++ b/components/treasuryV2/Details/DomainsDetails/Info/index.tsx
@@ -1,0 +1,45 @@
+import React from 'react'
+import cx from 'classnames'
+
+import * as Tabs from '@radix-ui/react-tabs'
+import Tab from '../../WalletDetails/Info/Tab'
+import { useTabState } from '../../tabState'
+
+import { Domains } from '@models/treasury/Asset'
+
+import Domain from './Domain'
+
+enum Choice {
+  Overview = 'Overview',
+}
+
+interface Props {
+  className?: string
+  domains: Domains
+}
+
+export default function Info(props: Props) {
+  const { get, set } = useTabState()
+
+  return (
+    <article className={cx(props.className, 'bg-bkg-3')}>
+      <Tabs.Root
+        value={get('domains') || Choice.Overview}
+        onValueChange={(newValue) => set('domains', newValue)}
+      >
+        <Tabs.List className="flex items-center border-b border-white/30 w-full">
+          <Tab value={Choice.Overview}>
+            <div className="flex items-center space-x-2">
+              <div>Overview</div>
+            </div>
+          </Tab>
+        </Tabs.List>
+        <Tabs.Content value={Choice.Overview}>
+          {props.domains.list.map((domain) => (
+            <Domain domain={domain} key={domain.address} />
+          ))}
+        </Tabs.Content>
+      </Tabs.Root>
+    </article>
+  )
+}

--- a/components/treasuryV2/Details/DomainsDetails/index.tsx
+++ b/components/treasuryV2/Details/DomainsDetails/index.tsx
@@ -1,0 +1,30 @@
+import React from 'react'
+import cx from 'classnames'
+
+import { Domains } from '@models/treasury/Asset'
+
+import Header from './Header'
+import Info from './Info'
+import StickyScrolledContainer from '../StickyScrolledContainer'
+
+interface Props {
+  className?: string
+  domains: Domains
+  isStickied?: boolean
+}
+
+export default function DomainsDetails(props: Props) {
+  return (
+    <div className={cx(props.className, 'rounded', 'overflow-hidden')}>
+      <StickyScrolledContainer
+        className="h-full"
+        isAncestorStickied={props.isStickied}
+      >
+        <Header domains={props.domains} />
+        <section className="p-6 bg-bkg-3">
+          <Info domains={props.domains} />
+        </section>
+      </StickyScrolledContainer>
+    </div>
+  )
+}

--- a/components/treasuryV2/Details/index.tsx
+++ b/components/treasuryV2/Details/index.tsx
@@ -13,6 +13,7 @@ import ProgramsDetails from './ProgramsDetails'
 import RealmAuthorityDetails from './RealmAuthorityDetails'
 import TokenDetails from './TokenDetails'
 import WalletDetails from './WalletDetails'
+import DomainsDetails from './DomainsDetails'
 import TokenOwnerRecordDetails from './TokenOwnerRecordDetails'
 
 function walletIsNotAuxiliary(
@@ -91,6 +92,10 @@ const Details = forwardRef<HTMLDivElement, Props>((props, ref) => {
                   nftCollection={props.data.data.asset}
                   isStickied={props.isStickied}
                 />
+              ) : props.data.data.asset.type === AssetType.Domain ? (
+                <DomainsDetails
+                  domains={props.data.data.asset}
+                  isStickied={props.isStickied}
               ) : props.data.data.asset.type ===
                   AssetType.TokenOwnerRecordAsset &&
                 walletIsNotAuxiliary(props.data.data.wallet) ? (

--- a/components/treasuryV2/Details/index.tsx
+++ b/components/treasuryV2/Details/index.tsx
@@ -96,6 +96,7 @@ const Details = forwardRef<HTMLDivElement, Props>((props, ref) => {
                 <DomainsDetails
                   domains={props.data.data.asset}
                   isStickied={props.isStickied}
+                />
               ) : props.data.data.asset.type ===
                   AssetType.TokenOwnerRecordAsset &&
                 walletIsNotAuxiliary(props.data.data.wallet) ? (

--- a/components/treasuryV2/WalletList/WalletListItem/AssetList/DomainListItem.tsx
+++ b/components/treasuryV2/WalletList/WalletListItem/AssetList/DomainListItem.tsx
@@ -1,0 +1,45 @@
+import React from 'react'
+import cx from 'classnames'
+
+import type { BigNumber } from 'bignumber.js'
+import { formatNumber } from '@utils/formatNumber'
+
+import { GlobeIcon } from '@heroicons/react/outline'
+
+import ListItem from './ListItem'
+
+interface Props {
+  className?: string
+  count: BigNumber
+  selected?: boolean
+  onSelect?(): void
+}
+
+export default function DomainListItem(props: Props) {
+  return (
+    <ListItem
+      className={props.className}
+      name="Domains"
+      rhs={
+        <div
+          className={cx(
+            'bg-bkg-1',
+            'flex',
+            'h-6',
+            'items-center',
+            'justify-center',
+            'rounded-full',
+            'text-sm',
+            'text-white',
+            'w-6'
+          )}
+        >
+          {formatNumber(props.count, undefined, { maximumFractionDigits: 0 })}
+        </div>
+      }
+      selected={props.selected}
+      thumbnail={<GlobeIcon className="stroke-fgd-1 h-6 w-6" />}
+      onSelect={props.onSelect}
+    />
+  )
+}

--- a/components/treasuryV2/WalletList/WalletListItem/AssetList/OtherAssetsList.tsx
+++ b/components/treasuryV2/WalletList/WalletListItem/AssetList/OtherAssetsList.tsx
@@ -4,6 +4,7 @@ import { CollectionIcon } from '@heroicons/react/outline'
 import {
   AssetType,
   Mint,
+  Domains,
   Programs,
   RealmAuthority,
   Unknown,
@@ -11,6 +12,7 @@ import {
 
 import Collapsible from './Collapsible'
 import MintListItem from './MintListItem'
+import DomainListItem from './DomainListItem'
 import ProgramsListItem from './ProgramsListItem'
 import UnknownAssetListItem from './UnknownAssetListItem'
 import RealmAuthorityListItem from './RealmAuthorityListItem'
@@ -19,9 +21,9 @@ interface Props {
   className?: string
   disableCollapse?: boolean
   expanded?: boolean
-  assets: (Mint | Programs | RealmAuthority | Unknown)[]
+  assets: (Mint | Domains | Programs | RealmAuthority | Unknown)[]
   selectedAssetId?: string | null
-  onSelect?(asset: Mint | Programs | RealmAuthority | Unknown): void
+  onSelect?(asset: Mint | Domains | Programs | RealmAuthority | Unknown): void
   onToggleExpand?(): void
 }
 
@@ -43,6 +45,15 @@ export default function OtherAssetsList(props: Props) {
               <MintListItem
                 key={i}
                 mint={asset}
+                selected={props.selectedAssetId === asset.id}
+                onSelect={() => props.onSelect?.(asset)}
+              />
+            )
+          case AssetType.Domain:
+            return (
+              <DomainListItem
+                key={i}
+                count={asset.count}
                 selected={props.selectedAssetId === asset.id}
                 onSelect={() => props.onSelect?.(asset)}
               />

--- a/components/treasuryV2/WalletList/WalletListItem/AssetList/index.tsx
+++ b/components/treasuryV2/WalletList/WalletListItem/AssetList/index.tsx
@@ -10,6 +10,7 @@ import {
   RealmAuthority,
   Unknown,
   AssetType,
+  Domain,
 } from '@models/treasury/Asset'
 
 import TokenList from './TokenList'
@@ -24,6 +25,7 @@ import {
   isPrograms,
   isRealmAuthority,
   isUnknown,
+  isDomain,
   isTokenOwnerRecord,
 } from '../typeGuards'
 
@@ -41,12 +43,13 @@ function isTokenLike(asset: Asset): asset is Token | Sol {
 
 function isOther(
   asset: Asset
-): asset is Mint | Programs | Unknown | RealmAuthority {
+): asset is Mint | Programs | Unknown | Domain | RealmAuthority {
   return (
     isMint(asset) ||
     isPrograms(asset) ||
     isUnknown(asset) ||
-    isRealmAuthority(asset)
+    isRealmAuthority(asset) ||
+    isDomain(asset)
   )
 }
 
@@ -146,7 +149,7 @@ export default function AssetList(props: Props) {
   )
 
   const [others, setOthers] = useState<
-    (Mint | Programs | Unknown | RealmAuthority)[]
+    (Mint | Programs | Unknown | Domain | RealmAuthority)[]
   >(othersFromProps)
 
   useEffect(() => {
@@ -176,7 +179,13 @@ export default function AssetList(props: Props) {
     }
 
     const getTokenData = async () => {
-      const newTokens: (Mint | Programs | Unknown | RealmAuthority)[] = []
+      const newTokens: (
+        | Mint
+        | Programs
+        | Unknown
+        | Domain
+        | RealmAuthority
+      )[] = []
       for await (const token of othersFromProps) {
         if (isMint(token)) {
           const newTokenData = await getTokenMetadata(token.address)

--- a/components/treasuryV2/WalletList/WalletListItem/AssetList/index.tsx
+++ b/components/treasuryV2/WalletList/WalletListItem/AssetList/index.tsx
@@ -10,7 +10,7 @@ import {
   RealmAuthority,
   Unknown,
   AssetType,
-  Domain,
+  Domains,
 } from '@models/treasury/Asset'
 
 import TokenList from './TokenList'
@@ -43,7 +43,7 @@ function isTokenLike(asset: Asset): asset is Token | Sol {
 
 function isOther(
   asset: Asset
-): asset is Mint | Programs | Unknown | Domain | RealmAuthority {
+): asset is Mint | Programs | Unknown | Domains | RealmAuthority {
   return (
     isMint(asset) ||
     isPrograms(asset) ||
@@ -149,7 +149,7 @@ export default function AssetList(props: Props) {
   )
 
   const [others, setOthers] = useState<
-    (Mint | Programs | Unknown | Domain | RealmAuthority)[]
+    (Mint | Programs | Unknown | Domains | RealmAuthority)[]
   >(othersFromProps)
 
   useEffect(() => {
@@ -183,7 +183,7 @@ export default function AssetList(props: Props) {
         | Mint
         | Programs
         | Unknown
-        | Domain
+        | Domains
         | RealmAuthority
       )[] = []
       for await (const token of othersFromProps) {

--- a/components/treasuryV2/WalletList/WalletListItem/typeGuards.ts
+++ b/components/treasuryV2/WalletList/WalletListItem/typeGuards.ts
@@ -7,6 +7,7 @@ import {
   Programs,
   RealmAuthority,
   Sol,
+  Domains,
   Unknown,
   TokenOwnerRecordAsset,
 } from '@models/treasury/Asset'
@@ -17,6 +18,10 @@ export function isToken(asset: Asset): asset is Token {
 
 export function isMint(asset: Asset): asset is Mint {
   return asset.type === AssetType.Mint
+}
+
+export function isDomain(asset: Asset): asset is Domains {
+  return asset.type === AssetType.Domain
 }
 
 export function isNFTCollection(asset: Asset): asset is NFTCollection {

--- a/hooks/useTreasuryInfo/assembleWallets.tsx
+++ b/hooks/useTreasuryInfo/assembleWallets.tsx
@@ -26,6 +26,8 @@ import {
 } from './groupProgramsByWallet'
 import { getRulesFromAccount } from './getRulesFromAccount'
 import { abbreviateAddress } from '@utils/formatting'
+import { Domain } from '@models/treasury/Domain'
+import { groupDomainsByWallet } from './groupDomainsByWallet'
 import { ConnectionContext } from '@utils/connection'
 import { PublicKey } from '@solana/web3.js'
 import getTokenOwnerRecordsForWallet from './getTokenOwnerRecordsForWallet'
@@ -39,6 +41,7 @@ export const assembleWallets = async (
   connection: ConnectionContext,
   accounts: AssetAccount[],
   nfts: NFT[],
+  domains: Domain[],
   programId: PublicKey,
   councilMintAddress?: string,
   communityMintAddress?: string,
@@ -57,6 +60,7 @@ export const assembleWallets = async (
     programId,
     programs
   )
+  const domainsGroupedByWallet = groupDomainsByWallet(domains)
   const ungovernedAssets: AssetAccount[] = []
   const governanceToWallet: { [address: string]: string } = {}
 
@@ -170,6 +174,27 @@ export const assembleWallets = async (
       id: 'program-list',
       count: new BigNumber(dataAccounts.length),
       list: dataAccounts,
+    })
+  }
+
+  for (const [walletAddress, domainList] of Object.entries(
+    domainsGroupedByWallet
+  )) {
+    if (!walletMap[walletAddress]) {
+      walletMap[walletAddress] = {
+        address: walletAddress,
+        assets: [],
+        rules: {},
+        stats: {},
+        totalValue: new BigNumber(0),
+      }
+    }
+
+    walletMap[walletAddress].assets.push({
+      type: AssetType.Domain,
+      id: 'domain-list',
+      count: new BigNumber(domainList.length),
+      list: domainList,
     })
   }
 

--- a/hooks/useTreasuryInfo/getDomains.ts
+++ b/hooks/useTreasuryInfo/getDomains.ts
@@ -1,0 +1,31 @@
+import { Connection } from '@solana/web3.js'
+import { AssetAccount } from '@utils/uiTypes/assets'
+import {
+  getAllDomains,
+  performReverseLookupBatch,
+} from '@bonfida/spl-name-service'
+import { Domain } from '@models/treasury/Domain'
+
+export const getDomains = async (
+  accounts: AssetAccount[],
+  connection: Connection
+) => {
+  const domainsArr: Domain[] = []
+  for (const account of accounts) {
+    const domains = await getAllDomains(connection, account.pubkey)
+
+    if (!domains.length) break
+
+    const reverse = await performReverseLookupBatch(connection, domains)
+
+    for (const [index, domain] of domains.entries()) {
+      domainsArr.push({
+        name: reverse[index],
+        address: domain.toBase58(),
+        owner: account.pubkey.toBase58(),
+      })
+    }
+  }
+
+  return domainsArr
+}

--- a/hooks/useTreasuryInfo/groupDomainsByWallet.ts
+++ b/hooks/useTreasuryInfo/groupDomainsByWallet.ts
@@ -1,0 +1,12 @@
+import { Domain } from '@models/treasury/Domain'
+
+export function groupDomainsByWallet(domains: Domain[]) {
+  return domains.reduce((acc, domain) => {
+    if (!acc[domain.owner]) {
+      acc[domain.owner] = []
+    }
+    acc[domain.owner].push(domain)
+
+    return acc
+  }, {} as { [wallet: string]: Domain[] })
+}

--- a/hooks/useTreasuryInfo/index.tsx
+++ b/hooks/useTreasuryInfo/index.tsx
@@ -35,7 +35,7 @@ export default function useTreasuryInfo(): Result<Data> {
   )
   const [nfts, setNfts] = useState<NFT[]>([])
   const [nftsLoading, setNftsLoading] = useState(true)
-  const [domainsLoading, setDoaminsLoading] = useState(true)
+  const [domainsLoading, setDomainsLoading] = useState(true)
   const [auxWallets, setAuxWallets] = useState<AuxiliaryWallet[]>([])
   const [wallets, setWallets] = useState<Wallet[]>([])
   const [domains, setDomains] = useState<Domain[]>([])
@@ -49,7 +49,7 @@ export default function useTreasuryInfo(): Result<Data> {
   useEffect(() => {
     if (!loadingGovernedAccounts && accounts.length) {
       setNftsLoading(true)
-      setDoaminsLoading(true)
+      setDomainsLoading(true)
       setBuildingWallets(true)
 
       getDomains(
@@ -57,7 +57,7 @@ export default function useTreasuryInfo(): Result<Data> {
         connection.current
       ).then((domainNames) => {
         setDomains(domainNames)
-        setDoaminsLoading(false)
+        setDomainsLoading(false)
       })
 
       getNfts(

--- a/hooks/useTreasuryInfo/index.tsx
+++ b/hooks/useTreasuryInfo/index.tsx
@@ -54,7 +54,7 @@ export default function useTreasuryInfo(): Result<Data> {
 
       getDomains(
         accounts.filter((acc) => acc.isSol),
-        connection
+        connection.current
       ).then((domainNames) => {
         setDomains(domainNames)
         setDoaminsLoading(false)
@@ -100,7 +100,15 @@ export default function useTreasuryInfo(): Result<Data> {
       )
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps -- TODO please fix, it can cause difficult bugs. You might wanna check out https://bobbyhadz.com/blog/react-hooks-exhaustive-deps for info. -@asktree
-  }, [accounts, nfts, nftsLoading, domains, domainsLoading, realmInfo, connection.current.rpcEndpoint])
+  }, [
+    accounts,
+    nfts,
+    nftsLoading,
+    domains,
+    domainsLoading,
+    realmInfo,
+    connection.current.rpcEndpoint,
+  ])
 
   useEffect(() => {
     setBuildingWallets(true)

--- a/hooks/useTreasuryInfo/index.tsx
+++ b/hooks/useTreasuryInfo/index.tsx
@@ -1,6 +1,7 @@
 import { BigNumber } from 'bignumber.js'
 import { useEffect, useMemo, useState } from 'react'
 
+import { Domain } from '@models/treasury/Domain'
 import { NFT } from '@models/treasury/NFT'
 import { Status, Result } from '@utils/uiTypes/Result'
 import { AuxiliaryWallet, Wallet } from '@models/treasury/Wallet'
@@ -11,6 +12,7 @@ import useWalletStore from 'stores/useWalletStore'
 import { assembleWallets } from './assembleWallets'
 import { calculateTokenCountAndValue } from './calculateTokenCountAndValue'
 import { getNfts } from './getNfts'
+import { getDomains } from './getDomains'
 
 interface Data {
   auxiliaryWallets: AuxiliaryWallet[]
@@ -33,8 +35,10 @@ export default function useTreasuryInfo(): Result<Data> {
   )
   const [nfts, setNfts] = useState<NFT[]>([])
   const [nftsLoading, setNftsLoading] = useState(true)
+  const [domainsLoading, setDoaminsLoading] = useState(true)
   const [auxWallets, setAuxWallets] = useState<AuxiliaryWallet[]>([])
   const [wallets, setWallets] = useState<Wallet[]>([])
+  const [domains, setDomains] = useState<Domain[]>([])
   const [buildingWallets, setBuildingWallets] = useState(true)
 
   const { counts, values } = useMemo(
@@ -45,7 +49,16 @@ export default function useTreasuryInfo(): Result<Data> {
   useEffect(() => {
     if (!loadingGovernedAccounts && accounts.length) {
       setNftsLoading(true)
+      setDoaminsLoading(true)
       setBuildingWallets(true)
+
+      getDomains(
+        accounts.filter((acc) => acc.isSol),
+        connection
+      ).then((domainNames) => {
+        setDomains(domainNames)
+        setDoaminsLoading(false)
+      })
 
       getNfts(
         accounts
@@ -68,13 +81,14 @@ export default function useTreasuryInfo(): Result<Data> {
   ])
 
   const walletsAsync = useMemo(() => {
-    if (nftsLoading || !realmInfo) {
+    if (nftsLoading || domainsLoading || !realmInfo) {
       return Promise.resolve({ wallets: [] })
     } else {
       return assembleWallets(
         connection,
         accounts,
         nfts,
+        domains,
         realmInfo.programId,
         realm?.account.config.councilMint?.toBase58(),
         realm?.account.communityMint?.toBase58(),
@@ -86,20 +100,20 @@ export default function useTreasuryInfo(): Result<Data> {
       )
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps -- TODO please fix, it can cause difficult bugs. You might wanna check out https://bobbyhadz.com/blog/react-hooks-exhaustive-deps for info. -@asktree
-  }, [accounts, nfts, nftsLoading, realmInfo, connection.current.rpcEndpoint])
+  }, [accounts, nfts, nftsLoading, domains, domainsLoading, realmInfo, connection.current.rpcEndpoint])
 
   useEffect(() => {
     setBuildingWallets(true)
     setWallets([])
 
-    if (!nftsLoading && realmInfo) {
+    if (!nftsLoading && !domainsLoading && realmInfo) {
       walletsAsync.then(({ auxiliaryWallets, wallets }) => {
         setWallets(wallets)
         setAuxWallets(auxiliaryWallets)
         setBuildingWallets(false)
       })
     }
-  }, [walletsAsync, nftsLoading, realmInfo])
+  }, [walletsAsync, nftsLoading, realmInfo, domainsLoading])
 
   if (!realmInfo || loadingGovernedAccounts || nftsLoading || buildingWallets) {
     return {

--- a/models/treasury/Asset.ts
+++ b/models/treasury/Asset.ts
@@ -13,7 +13,6 @@ import { NFT } from './NFT'
 import { Program } from './Program'
 import { Domain } from './Domain'
 
-
 import { TokenProgramAccount } from '@utils/tokens'
 import { MintInfo } from '@solana/spl-token'
 
@@ -109,12 +108,12 @@ export interface Unknown {
   name: string
 }
 
-
 export interface Domains {
   type: AssetType.Domain
   id: string
   count: BigNumber
   list: Domain[]
+}
 
 export interface TokenOwnerRecordAsset {
   type: AssetType.TokenOwnerRecordAsset

--- a/models/treasury/Asset.ts
+++ b/models/treasury/Asset.ts
@@ -11,13 +11,18 @@ import type { AssetAccount } from '@utils/uiTypes/assets'
 
 import { NFT } from './NFT'
 import { Program } from './Program'
+import { Domain } from './Domain'
+
+
 import { TokenProgramAccount } from '@utils/tokens'
 import { MintInfo } from '@solana/spl-token'
+
 import { PublicKey } from '@solana/web3.js'
 
 export enum AssetType {
   Mint,
   NFTCollection,
+  Domain,
   Programs,
   RealmAuthority,
   Sol,
@@ -104,6 +109,13 @@ export interface Unknown {
   name: string
 }
 
+
+export interface Domains {
+  type: AssetType.Domain
+  id: string
+  count: BigNumber
+  list: Domain[]
+
 export interface TokenOwnerRecordAsset {
   type: AssetType.TokenOwnerRecordAsset
   id: string
@@ -123,6 +135,7 @@ export interface TokenOwnerRecordAsset {
 export type Asset =
   | Mint
   | NFTCollection
+  | Domains
   | Programs
   | RealmAuthority
   | Sol

--- a/models/treasury/Domain.ts
+++ b/models/treasury/Domain.ts
@@ -1,5 +1,5 @@
 export interface Domain {
   owner: string
-  name: string | undefined
+  name?: string
   address: string
 }

--- a/models/treasury/Domain.ts
+++ b/models/treasury/Domain.ts
@@ -1,0 +1,5 @@
+export interface Domain {
+  owner: string
+  name: string | undefined
+  address: string
+}

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -9,8 +9,11 @@ import { App as HubApp } from '@hub/App'
 import '../styles/index.css'
 import '../styles/typography.css'
 import '@hub/components/controls/RichTextEditor/index.css'
+import '../components/DropdownMenu/index.css'
+
 import { useEffect } from 'react'
 import useSerumGovStore from 'stores/useSerumGovStore'
+
 
 export default function App({ Component, pageProps, router }: AppProps) {
   const { cluster } = router.query


### PR DESCRIPTION
- Adds Domains category to Other Assets in Wallets & Assets view. 
- Fetches and adds domains to corresponding wallets in useTreasuryInfo hook as another asset class. 
 
<img width="1535" alt="Screenshot 2022-11-12 at 19 42 16" src="https://user-images.githubusercontent.com/75177443/201489754-d690f2d9-f3f4-472d-94c5-b7837ed304c4.png">
