### PR TITLE
Fix user-affecting validation bug in community token wizard

### DIFF
--- a/components/NewRealmWizard/components/steps/CommunityTokenDetailsForm.tsx
+++ b/components/NewRealmWizard/components/steps/CommunityTokenDetailsForm.tsx
@@ -44,11 +44,8 @@ export const CommunityTokenSchema = {
     .number()
     .positive('Must be greater than 0')
     .transform((value) => (isNaN(value) ? undefined : value))
-    .when(['suggestedMinTokenAmount', 'useExistingCommunityToken'], {
-      is: (suggestedMinTokenAmount, useExistingCommunityToken) => {
-        if (useExistingCommunityToken === false) return false
-        return suggestedMinTokenAmount > 0
-      },
+    .when('useExistingCommunityToken', {
+      is: false,
       then: (schema) => schema.required('Required'),
       otherwise: (schema) => schema.optional(),
     }),
@@ -95,7 +92,11 @@ export default function CommunityTokenForm({
     setValue,
     handleSubmit,
     formState: { isValid },
-  } = useForm({
+  } = useForm<any>({
+    // @asktree: I set default values here in order to eliminate a bug where a value was only being set as a side effect of opening advanced options
+    defaultValues: {
+      useSupplyFactor: true,
+    },
     mode: 'all',
     resolver: yupResolver(schema),
   })
@@ -107,27 +108,25 @@ export default function CommunityTokenForm({
 
   useEffect(() => {
     updateUserInput(formData, CommunityTokenSchema, setValue)
-    // eslint-disable-next-line react-hooks/exhaustive-deps -- TODO please fix, it can cause difficult bugs. You might wanna check out https://bobbyhadz.com/blog/react-hooks-exhaustive-deps for info. -@asktree
-  }, [])
+  }, [formData, setValue])
 
   useEffect(() => {
     if (!useExistingCommunityToken) {
       setValue('communityTokenMintAddress', undefined)
+      // @asktree: it seems wrong that this would be a form value at all given that it has no corresponding user input.
       setValue('suggestedMinTokenAmount', undefined)
       setValue('minimumNumberOfCommunityTokensToGovern', undefined)
       setValue('transferCommunityMintAuthority', undefined, {
         shouldValidate: true,
       })
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps -- TODO please fix, it can cause difficult bugs. You might wanna check out https://bobbyhadz.com/blog/react-hooks-exhaustive-deps for info. -@asktree
-  }, [useExistingCommunityToken])
+  }, [setValue, useExistingCommunityToken])
 
   useEffect(() => {
     if (useSupplyFactor) {
       setValue('communityAbsoluteMaxVoteWeight', undefined)
     } else setValue('communityMintSupplyFactor', undefined)
-    // eslint-disable-next-line react-hooks/exhaustive-deps -- TODO please fix, it can cause difficult bugs. You might wanna check out https://bobbyhadz.com/blog/react-hooks-exhaustive-deps for info. -@asktree
-  }, [useSupplyFactor])
+  }, [setValue, useSupplyFactor])
 
   function handleTokenInput({ suggestedMinTokenAmount, tokenInfo }) {
     setCommunityTokenInfo(tokenInfo)
@@ -190,8 +189,7 @@ export default function CommunityTokenForm({
           name="useExistingCommunityToken"
           control={control}
           defaultValue={undefined}
-          // eslint-disable-next-line @typescript-eslint/no-unused-vars
-          render={({ field: { ref, ...field } }) => (
+          render={({ field: { ref: _, ...field } }) => (
             <div className="pt-3">
               <FormField
                 title="Do you have an existing token for your DAO's community?"
@@ -249,8 +247,7 @@ export default function CommunityTokenForm({
           name="useSupplyFactor"
           control={control}
           defaultValue={true}
-          // eslint-disable-next-line @typescript-eslint/no-unused-vars
-          render={({ field: { ref, ...field } }) => (
+          render={({ field: { ref: _, ...field } }) => (
             <div className="pt-3">
               <FormField
                 title="What type of max voter weight do you want to use?"


### PR DESCRIPTION
This PR fixes two user-affecting bugs from the community token wizard http://localhost:3000/realms/new/community-token?cluster=devnet
1) The `useSupplyFactor` form value was being set to its defaut value as a side effect of opening the Advanced Options, despite being required. 
2) The logic for requiring `minimumNumberOfCommunityTokensToGovern` was incorrect such that it was never required even though it sometimes needs to be.


<img width="854" alt="image" src="https://user-images.githubusercontent.com/12001874/201544387-edaa568c-6781-4198-b3be-b543738aefae.png">
(view provided for your reference. previously it was impossible to see this "Required" error and you would be allowed to proceed with no input -- but only if you opened Advanced Options first)

(While I was here I also fixed exhaustive-deps violations)
