### PR TITLE
Fix solana wallet not being displayed under DAO Wallet & assets

### DIFF
--- a/stores/useGovernanceAssetsStore.tsx
+++ b/stores/useGovernanceAssetsStore.tsx
@@ -45,7 +45,7 @@ import {
   AccountTypeToken,
   AssetAccount,
 } from '@utils/uiTypes/assets'
-import { chunks } from '@utils/helpers'
+import group from '@utils/group'
 
 const tokenAccountOwnerOffset = 32
 
@@ -410,7 +410,7 @@ const getSolAccountObj = async (
     }
   )
 
-  const groups = chunks(tokenAccountsOwnedBySolAccounts, 100)
+  const groups = group(tokenAccountsOwnedBySolAccounts)
 
   const mintAccounts = (
     await Promise.all(
@@ -683,7 +683,7 @@ const loadGovernedTokenAccounts = async (
   const tokenAccountsInfo = (
     await Promise.all(
       // Load infos in batch, cannot load 9999 accounts within one request
-      chunks(tokenAccountsOwnedByGovernances, 100).map((group) =>
+      group(tokenAccountsOwnedByGovernances, 100).map((group) =>
         getTokenAccountsInfo(connection, group)
       )
     )
@@ -692,7 +692,7 @@ const loadGovernedTokenAccounts = async (
   const governedTokenAccounts = (
     await Promise.all(
       // Load infos in batch, cannot load 9999 accounts within one request
-      chunks(tokenAccountsInfo, 100).map((group) =>
+      group(tokenAccountsInfo).map((group) =>
         getTokenAssetAccounts(group, governancesArray, realm, connection)
       )
     )


### PR DESCRIPTION
This PR fixes a bug introduced by https://github.com/solana-labs/governance-ui/commit/e4f224e6aafe1c233b25cf2e47268d373396f800

Result:

<img width="813" alt="Screenshot 2022-11-26 at 18 14 59" src="https://user-images.githubusercontent.com/22965416/204096373-f5849bd0-91eb-4375-97e3-6598d07ffc7c.png">

**Bug explanation**:

- `chunks` function returns empty array if there are no element
- `group` function returns array with empty element if there are no element

with chunks, the function `getTokenAssetAccounts` were not called.


Thanks to @abrzezinski94 for reporting the bug