### PR TITLE
Agrippa/version-hotfix

### DIFF
--- a/components/NewRealmWizard/PageTemplate.tsx
+++ b/components/NewRealmWizard/PageTemplate.tsx
@@ -12,7 +12,7 @@ import { FORM_NAME as MULTISIG_WALLET_FORM } from 'pages/realms/new/multisig'
 import { FORM_NAME as COMMUNITY_TOKEN_FORM } from 'pages/realms/new/community-token'
 import { useProgramVersionByIdQuery } from '@hooks/queries/useProgramVersionQuery'
 import { PublicKey } from '@blockworks-foundation/mango-client'
-import { DEFAULT_GOVERNANCE_PROGRAM_VERSION } from '@components/instructions/tools'
+import { DEFAULT_GOVERNANCE_PROGRAM_ID } from '@components/instructions/tools'
 
 export const Section = ({ children }) => {
   return (
@@ -31,12 +31,13 @@ export default function FormPage({
 }) {
   const { connected, current: wallet } = useWalletStore((s) => s)
   const userAddress = wallet?.publicKey?.toBase58()
+
+  const { query, push } = useRouter()
   const [formData, setFormData] = useState<any>({
-    _programVersion: DEFAULT_GOVERNANCE_PROGRAM_VERSION,
+    _programVersion: undefined,
     memberAddresses:
       autoInviteWallet && userAddress ? [userAddress] : undefined,
   })
-  const { query, push } = useRouter()
   const currentStep = formData?.currentStep || 0
   const title = `Create ${
     type === MULTISIG_WALLET_FORM
@@ -47,7 +48,8 @@ export default function FormPage({
   } | Realms`
 
   // Update formData's _programVersion
-  const programIdInput = formData.programId
+  const programIdInput =
+    formData.programId ?? DEFAULT_GOVERNANCE_PROGRAM_ID.toString()
   const validProgramId =
     programIdInput && validateSolAddress(programIdInput)
       ? new PublicKey(programIdInput)
@@ -55,11 +57,12 @@ export default function FormPage({
   const programVersionQuery = useProgramVersionByIdQuery(validProgramId)
 
   useEffect(() => {
-    setFormData((prev) => ({
-      ...prev,
-      _programVersion:
-        programVersionQuery.data ?? DEFAULT_GOVERNANCE_PROGRAM_VERSION,
-    }))
+    if (programVersionQuery.data) {
+      setFormData((prev) => ({
+        ...prev,
+        _programVersion: programVersionQuery.data,
+      }))
+    }
   }, [programVersionQuery.data])
 
   useEffect(() => {

--- a/components/instructions/tools.tsx
+++ b/components/instructions/tools.tsx
@@ -42,12 +42,6 @@ export const V2_DEFAULT_GOVERNANCE_PROGRAM_ID =
 export const DEFAULT_GOVERNANCE_PROGRAM_ID = V2_DEFAULT_GOVERNANCE_PROGRAM_ID
 export const DEFAULT_GOVERNANCE_PROGRAM_VERSION = 2
 
-/**
- * Default TEST governance program id instance
- */
-export const DEFAULT_TEST_GOVERNANCE_PROGRAM_ID =
-  'GTesTBiEWE32WHXXE2S4XbZvA5CrEc4xs6ZgRe895dP'
-
 export const MANGO_DAO_TREASURY = '9RGoboEjmaAjSCXsKi6p6zJucnwF3Eg5NUN9jPS6ziL3'
 
 // Well known account names displayed on the instruction card

--- a/hooks/queries/useProgramVersionQuery.ts
+++ b/hooks/queries/useProgramVersionQuery.ts
@@ -1,11 +1,12 @@
+import { EndpointTypes } from '@models/types'
 import { getGovernanceProgramVersion } from '@solana/spl-governance'
-import { Connection, PublicKey } from '@solana/web3.js'
+import { PublicKey } from '@solana/web3.js'
 import { useQuery } from '@tanstack/react-query'
 import useWalletStore from 'stores/useWalletStore'
-import queryClient from './queryClient'
 
 export const programVersionQueryKeys = {
-  byProgramId: (programId: PublicKey) => [
+  byProgramId: (cluster: EndpointTypes, programId: PublicKey) => [
+    cluster,
     'programVersion',
     programId.toString(),
   ],
@@ -17,7 +18,8 @@ export function useProgramVersionByIdQuery(realmsProgramId?: PublicKey) {
 
   const query = useQuery({
     queryKey:
-      realmsProgramId && programVersionQueryKeys.byProgramId(realmsProgramId),
+      realmsProgramId &&
+      programVersionQueryKeys.byProgramId(connection.cluster, realmsProgramId),
     queryFn: () =>
       getGovernanceProgramVersion(connection.current, realmsProgramId!),
     enabled: realmsProgramId !== undefined,
@@ -27,12 +29,3 @@ export function useProgramVersionByIdQuery(realmsProgramId?: PublicKey) {
 
   return query
 }
-
-export const fetchProgramVersionById = (
-  connection: Connection,
-  programId: PublicKey
-) =>
-  queryClient.fetchQuery({
-    queryKey: programVersionQueryKeys.byProgramId(programId),
-    queryFn: () => getGovernanceProgramVersion(connection, programId),
-  })

--- a/hooks/useProgramVersion.ts
+++ b/hooks/useProgramVersion.ts
@@ -1,35 +1,12 @@
-import {
-  V2_DEFAULT_GOVERNANCE_PROGRAM_ID,
-  V3_DEFAULT_GOVERNANCE_PROGRAM_ID,
-} from '@components/instructions/tools'
-import { useRouter } from 'next/router'
-import { useMemo } from 'react'
 import useWalletStore from 'stores/useWalletStore'
 
+// TODO replace with useProgramVersionQuery
 const useProgramVersion = () => {
-  const router = useRouter()
-  const { symbol } = router.query
-
-  // @asktree: Why is this in the body of the hook despite depending on no data from it, you ask?
-  // I was suddenly getting some insane `ReferenceError: Cannot access 'V3_DEFAULT_GOVERNANCE_PROGRAM_ID' before initialization` error that I cannot fathom.
-  // Rather than lose time and braincells I am just going to put this constant in the body of the hook.
-  const CACHE = useMemo(
-    () =>
-      ({
-        [V3_DEFAULT_GOVERNANCE_PROGRAM_ID]: 3,
-        GTesTBiEWE32WHXXE2S4XbZvA5CrEc4xs6ZgRe895dP: 2,
-        [V2_DEFAULT_GOVERNANCE_PROGRAM_ID]: 2,
-      } as const),
-    []
-  )
-
-  const cachedVersion = CACHE[symbol as string] as 2 | 3 | undefined
-
   // TODO this should really return undefined, not 1, when we don't know the answer yet.
   const queriedVersion = useWalletStore(
     (s) => s.selectedRealm.programVersion as 1 | 2 | 3
   )
-  return cachedVersion ?? queriedVersion
+  return queriedVersion
 }
 
 export default useProgramVersion


### PR DESCRIPTION
This PR makes it where the wizards always check program version, rather than using a hard-coded version number when the default program is used.

It also fixes a bug wherein changing clusters would not refetch the program version query on the new cluster.