### PR TITLE
Fix createSetRealmConfig

### DIFF
--- a/pages/dao/[symbol]/params/RealmConfigModal.tsx
+++ b/pages/dao/[symbol]/params/RealmConfigModal.tsx
@@ -140,7 +140,7 @@ const RealmConfigModal = ({ closeProposalModal, isProposalModalOpen }) => {
               // Pass the payer only if RealmConfigAccount doens't exist and needs to be created
               // TODO: If payer is passed then only the payer can execute the proposal
               //       We should use the DAO Wallet instead, and top it up if there is not enough SOL there
-              realmConfig ? wallet.publicKey : undefined
+              !realmConfig ? wallet.publicKey : undefined
             )
           : await createSetRealmConfig(
               realmInfo.programId,
@@ -167,7 +167,7 @@ const RealmConfigModal = ({ closeProposalModal, isProposalModalOpen }) => {
               // Pass the payer only if RealmConfigAccount doens't exist and needs to be created
               // TODO: If payer is passed then only the payer can execute the proposal
               //       We should use the DAO Wallet instead, and top it up if there is not enough SOL there
-              realmConfig ? wallet.publicKey : undefined
+              !realmConfig ? wallet.publicKey : undefined
             )
 
       serializedInstruction = serializeInstructionToBase64(instruction)


### PR DESCRIPTION
**Bug description**

When changing the realm config, if you have a governance created in v2, payer account is missing to create the `RealmConfigAccount`.

<img width="768" alt="Screenshot 2023-01-13 at 13 56 39" src="https://user-images.githubusercontent.com/22965416/212291925-79ad88ec-1f50-4da2-bb28-fc87b18973b8.png">

Example of failed transaction:

https://explorer.solana.com/tx/iTLqY8FQ5k7if3gCEvQhtL2baMe5uughmsBkDsCGXThBMwdcALqY8wZwh5gGWgzM2x68ovYmZig7VNjuUUUoD92

Example of transaction with correct accounts:

https://explorer.solana.com/tx/inspector?signatures=%255B%255D&message=AgEDCAeT1o%252F1%252FRYQX7RYi7M5wJ4ZOjgXblnEfFxxzU2iCrispFXopaQKx1qy37nerhH53xz66m6Xwo8OKfoBiUIiGl4yDIn2gzDcF%252BkvJphMpWibUF9wtxtg8f%252BnHHyuo6yQ82WXEsSKN8u2dz8YuTmrE1vyWPbTRzCD66xDbS64vN9d4ZFqB%252FIR1vLpX3EpQEtZ0vLiMcZBaiuZwK0nkodA41kAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAB%252F6%252FioJLGmz1Ksg%252FR3tr24Mw6VBQ1UvNi9u03wBNq7P6uQ1ve51tzTNWT7PmjBLgCS6KJhnt2mx%252BTynu7iORv4UbyaHNwBpM7VhqPYXKZNRnQqmL8VpNFGx4%252Bd8I4Q0zQEHBwQBBgMFAgAZFgEAAOiJBCPHigDWYTGGAAAAAAAAAAAAAA%253D%253D

**Fix**

Add a payer account when `RealmConfigAccount` doesn't exist
