### PR TITLE
PsyOptions claim quote/underlying and exercise

### DIFF
--- a/hooks/useGovernanceAssets.ts
+++ b/hooks/useGovernanceAssets.ts
@@ -731,6 +731,10 @@ export default function useGovernanceAssets() {
       name: 'Claim Quote with Writer Token',
       packageId: PackageEnum.PsyFinance,
     },
+    [Instructions.PsyFinanceClaimUnderlyingPostExpiration]: {
+      name: 'Claim Underlying (post expiration)',
+      packageId: PackageEnum.PsyFinance,
+    },
 
     /*
       ███████ ███████ ██████  ██    ██ ███    ███

--- a/hooks/useGovernanceAssets.ts
+++ b/hooks/useGovernanceAssets.ts
@@ -735,6 +735,10 @@ export default function useGovernanceAssets() {
       name: 'Claim Underlying (post expiration)',
       packageId: PackageEnum.PsyFinance,
     },
+    [Instructions.PsyFinanceExerciseOption]: {
+      name: 'Exercise Option',
+      packageId: PackageEnum.PsyFinance,
+    },
 
     /*
       ███████ ███████ ██████  ██    ██ ███    ███

--- a/hooks/useGovernanceAssets.ts
+++ b/hooks/useGovernanceAssets.ts
@@ -724,7 +724,11 @@ export default function useGovernanceAssets() {
     */
 
     [Instructions.PsyFinanceMintAmericanOptions]: {
-      name: 'Mint American Options',
+      name: ' Mint American Options',
+      packageId: PackageEnum.PsyFinance,
+    },
+    [Instructions.PsyFinanceBurnWriterForQuote]: {
+      name: 'Claim Quote with Writer Token',
       packageId: PackageEnum.PsyFinance,
     },
 

--- a/pages/dao/[symbol]/proposal/components/instructions/PsyFinance/BurnWriterTokenForQuote.tsx
+++ b/pages/dao/[symbol]/proposal/components/instructions/PsyFinance/BurnWriterTokenForQuote.tsx
@@ -123,8 +123,7 @@ const BurnWriterTokenForQuote = ({
 
     const ix = program.instruction.burnWriterForQuote(new BN(form.size), {
       accounts: {
-        // @ts-ignore
-        userAuthority: program.provider.wallet.publicKey,
+        userAuthority: form.writerTokenAccount.extensions.token!.account.owner,
         optionMarket: optionAccount.publicKey,
         writerTokenMint: optionAccount.account.writerTokenMint,
         writerTokenSrc: form.writerTokenAccount.extensions.token!.publicKey,

--- a/pages/dao/[symbol]/proposal/components/instructions/PsyFinance/BurnWriterTokenForQuote.tsx
+++ b/pages/dao/[symbol]/proposal/components/instructions/PsyFinance/BurnWriterTokenForQuote.tsx
@@ -1,4 +1,3 @@
-import { ProgramAccount as AnchorProgramAccount } from '@project-serum/anchor'
 import {
   Governance,
   ProgramAccount,
@@ -6,8 +5,7 @@ import {
 } from '@solana/spl-governance'
 import { PsyFinanceBurnWriterForQuote } from '@utils/uiTypes/proposalCreationTypes'
 import useWallet from '@hooks/useWallet'
-import useGovernanceAssets from '@hooks/useGovernanceAssets'
-import { useContext, useEffect, useMemo, useReducer, useState } from 'react'
+import { useContext, useEffect, useReducer } from 'react'
 import { NewProposalContext } from '../../../new'
 import { AssetAccount } from '@utils/uiTypes/assets'
 import GovernedAccountSelect from '../../GovernedAccountSelect'
@@ -15,9 +13,10 @@ import Input from '@components/inputs/Input'
 import Tooltip from '@components/Tooltip'
 import { Program } from '@project-serum/anchor'
 import {
-  OptionMarket,
   PsyAmericanIdl,
   PSY_AMERICAN_PROGRAM_ID,
+  useGovernedWriterTokenAccounts,
+  useOptionAccounts,
 } from '@utils/instructions/PsyFinance'
 import { PublicKey, TransactionInstruction } from '@solana/web3.js'
 import { getATA } from '@utils/ataTools'
@@ -44,26 +43,9 @@ const BurnWriterTokenForQuote = ({
   governance: ProgramAccount<Governance> | null
 }) => {
   const { anchorProvider, connection, wallet } = useWallet()
-  const { governedTokenAccountsWithoutNfts } = useGovernanceAssets()
   const { handleSetInstructions } = useContext(NewProposalContext)
-  const [options, setOptions] = useState<
-    AnchorProgramAccount<OptionMarket>[] | null
-  >(null)
-  const governedWriterTokenAccounts = useMemo(() => {
-    const _accounts: AssetAccount[] = []
-    options?.forEach((option) => {
-      const govWriterTokenAccount = governedTokenAccountsWithoutNfts.find(
-        (gAcct) =>
-          gAcct.extensions.token?.account.mint.equals(
-            option.account.writerTokenMint
-          )
-      )
-      if (govWriterTokenAccount) {
-        _accounts.push(govWriterTokenAccount)
-      }
-    })
-    return _accounts
-  }, [governedTokenAccountsWithoutNfts, options])
+  const options = useOptionAccounts()
+  const governedWriterTokenAccounts = useGovernedWriterTokenAccounts(options)
 
   const [form, dispatch] = useReducer(formReducer, {
     size: 0,
@@ -140,20 +122,6 @@ const BurnWriterTokenForQuote = ({
       governance: form.writerTokenAccount?.governance,
     }
   }
-
-  useEffect(() => {
-    const program = new Program(
-      PsyAmericanIdl,
-      PSY_AMERICAN_PROGRAM_ID,
-      anchorProvider
-    )
-    ;(async () => {
-      const _options = (await program.account.optionMarket.all()) as
-        | AnchorProgramAccount<OptionMarket>[]
-        | null
-      setOptions(_options)
-    })()
-  }, [anchorProvider])
 
   useEffect(() => {
     handleSetInstructions(

--- a/pages/dao/[symbol]/proposal/components/instructions/PsyFinance/BurnWriterTokenForQuote.tsx
+++ b/pages/dao/[symbol]/proposal/components/instructions/PsyFinance/BurnWriterTokenForQuote.tsx
@@ -1,0 +1,211 @@
+import { ProgramAccount as AnchorProgramAccount } from '@project-serum/anchor'
+import {
+  Governance,
+  ProgramAccount,
+  serializeInstructionToBase64,
+} from '@solana/spl-governance'
+import { PsyFinanceBurnWriterForQuote } from '@utils/uiTypes/proposalCreationTypes'
+import useWallet from '@hooks/useWallet'
+import useGovernanceAssets from '@hooks/useGovernanceAssets'
+import { useContext, useEffect, useMemo, useReducer, useState } from 'react'
+import { NewProposalContext } from '../../../new'
+import { AssetAccount } from '@utils/uiTypes/assets'
+import GovernedAccountSelect from '../../GovernedAccountSelect'
+import Input from '@components/inputs/Input'
+import Tooltip from '@components/Tooltip'
+import { Program } from '@project-serum/anchor'
+import {
+  OptionMarket,
+  PsyAmericanIdl,
+  PSY_AMERICAN_PROGRAM_ID,
+} from '@utils/instructions/PsyFinance'
+import { PublicKey, TransactionInstruction } from '@solana/web3.js'
+import { getATA } from '@utils/ataTools'
+import {
+  ASSOCIATED_TOKEN_PROGRAM_ID,
+  Token,
+  TOKEN_PROGRAM_ID,
+} from '@solana/spl-token'
+import { BN } from 'bn.js'
+
+const formReducer = (
+  state: PsyFinanceBurnWriterForQuote,
+  action: Partial<PsyFinanceBurnWriterForQuote>
+) => ({
+  ...state,
+  ...action,
+})
+
+const BurnWriterTokenForQuote = ({
+  index,
+  governance,
+}: {
+  index: number
+  governance: ProgramAccount<Governance> | null
+}) => {
+  const { anchorProvider, connection, wallet } = useWallet()
+  const { governedTokenAccountsWithoutNfts } = useGovernanceAssets()
+  const { handleSetInstructions } = useContext(NewProposalContext)
+  const [options, setOptions] = useState<
+    AnchorProgramAccount<OptionMarket>[] | null
+  >(null)
+  const governedWriterTokenAccounts = useMemo(() => {
+    const _accounts: AssetAccount[] = []
+    options?.forEach((option) => {
+      const govWriterTokenAccount = governedTokenAccountsWithoutNfts.find(
+        (gAcct) =>
+          gAcct.extensions.token?.account.mint.equals(
+            option.account.writerTokenMint
+          )
+      )
+      if (govWriterTokenAccount) {
+        _accounts.push(govWriterTokenAccount)
+      }
+    })
+    return _accounts
+  }, [governedTokenAccountsWithoutNfts, options])
+
+  const [form, dispatch] = useReducer(formReducer, {
+    size: 0,
+    writerTokenAccount: undefined,
+    quoteDestination: '',
+  })
+
+  const shouldBeGoverned = !!(index !== 0 && governance)
+
+  const getInstruction = async () => {
+    if (!form.size || !form.writerTokenAccount) {
+      throw new Error('Missing input(s)')
+    }
+    const program = new Program(
+      PsyAmericanIdl,
+      PSY_AMERICAN_PROGRAM_ID,
+      anchorProvider
+    )
+
+    const prerequisiteInstructions: TransactionInstruction[] = []
+
+    const optionAccount = options?.find((_option) =>
+      _option.account.writerTokenMint.equals(
+        form.writerTokenAccount?.extensions.token?.account.mint ??
+          PublicKey.default
+      )
+    )
+    if (!optionAccount) {
+      throw new Error('Invalid option from writer token account')
+    }
+
+    let quoteDestination
+    if (form.quoteDestination) {
+      quoteDestination = new PublicKey(form.quoteDestination ?? 0)
+    } else {
+      const { currentAddress, needToCreateAta } = await getATA({
+        connection,
+        receiverAddress: form.writerTokenAccount!.extensions.token!.account
+          .owner,
+        mintPK: optionAccount.account.quoteAssetMint,
+        wallet,
+      })
+      if (needToCreateAta) {
+        prerequisiteInstructions.push(
+          Token.createAssociatedTokenAccountInstruction(
+            ASSOCIATED_TOKEN_PROGRAM_ID,
+            TOKEN_PROGRAM_ID,
+            optionAccount.account.quoteAssetMint,
+            currentAddress,
+            form.writerTokenAccount!.extensions.token!.account.owner,
+            wallet?.publicKey as PublicKey
+          )
+        )
+      }
+      quoteDestination = currentAddress
+    }
+
+    const ix = program.instruction.burnWriterForQuote(new BN(form.size), {
+      accounts: {
+        // @ts-ignore
+        userAuthority: program.provider.wallet.publicKey,
+        optionMarket: optionAccount.publicKey,
+        writerTokenMint: optionAccount.account.writerTokenMint,
+        writerTokenSrc: form.writerTokenAccount.extensions.token!.publicKey,
+        quoteAssetPool: optionAccount.account.quoteAssetPool,
+        writerQuoteDest: quoteDestination,
+        tokenProgram: TOKEN_PROGRAM_ID,
+      },
+    })
+
+    return {
+      serializedInstruction: serializeInstructionToBase64(ix),
+      isValid: true,
+      prerequisiteInstructions,
+      governance: form.writerTokenAccount?.governance,
+    }
+  }
+
+  useEffect(() => {
+    const program = new Program(
+      PsyAmericanIdl,
+      PSY_AMERICAN_PROGRAM_ID,
+      anchorProvider
+    )
+    ;(async () => {
+      const _options = (await program.account.optionMarket.all()) as
+        | AnchorProgramAccount<OptionMarket>[]
+        | null
+      setOptions(_options)
+    })()
+  }, [anchorProvider])
+
+  useEffect(() => {
+    handleSetInstructions(
+      { governedAccount: form.writerTokenAccount?.governance, getInstruction },
+      index
+    )
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [form, handleSetInstructions, index])
+
+  return (
+    <>
+      <GovernedAccountSelect
+        label="Writer Token source account"
+        governedAccounts={governedWriterTokenAccounts}
+        onChange={(value: AssetAccount) => {
+          dispatch({
+            writerTokenAccount: value,
+          })
+        }}
+        value={form.writerTokenAccount}
+        shouldBeGoverned={shouldBeGoverned}
+        governance={governance}
+        type="token"
+      />
+      <Input
+        label="Amount (must be integer)"
+        value={form.size}
+        type="number"
+        onChange={(event) =>
+          dispatch({
+            size: parseInt(event.target.value),
+          })
+        }
+      />
+
+      {/* Advanced configurations */}
+
+      <Tooltip content="Address the Quote asset will be transferred to. Leaving empty will use (or create) a governed SPL token account for the tokens.">
+        <Input
+          label="(optional) Quote destination address"
+          value={form.quoteDestination}
+          onChange={(event) => {
+            dispatch({
+              quoteDestination: event.target.value,
+            })
+          }}
+          type="string"
+        />
+      </Tooltip>
+    </>
+  )
+}
+
+export default BurnWriterTokenForQuote

--- a/pages/dao/[symbol]/proposal/components/instructions/PsyFinance/ClaimUnderlyingPostExpiration.tsx
+++ b/pages/dao/[symbol]/proposal/components/instructions/PsyFinance/ClaimUnderlyingPostExpiration.tsx
@@ -1,0 +1,217 @@
+import { ProgramAccount as AnchorProgramAccount } from '@project-serum/anchor'
+import {
+  Governance,
+  ProgramAccount,
+  serializeInstructionToBase64,
+} from '@solana/spl-governance'
+import { PsyFinanceClaimUnderlyingPostExpiration } from '@utils/uiTypes/proposalCreationTypes'
+import useWallet from '@hooks/useWallet'
+import useGovernanceAssets from '@hooks/useGovernanceAssets'
+import { useContext, useEffect, useMemo, useReducer, useState } from 'react'
+import { NewProposalContext } from '../../../new'
+import { AssetAccount } from '@utils/uiTypes/assets'
+import GovernedAccountSelect from '../../GovernedAccountSelect'
+import Input from '@components/inputs/Input'
+import Tooltip from '@components/Tooltip'
+import { Program } from '@project-serum/anchor'
+import {
+  OptionMarket,
+  PsyAmericanIdl,
+  PSY_AMERICAN_PROGRAM_ID,
+} from '@utils/instructions/PsyFinance'
+import {
+  PublicKey,
+  SYSVAR_CLOCK_PUBKEY,
+  TransactionInstruction,
+} from '@solana/web3.js'
+import { getATA } from '@utils/ataTools'
+import {
+  ASSOCIATED_TOKEN_PROGRAM_ID,
+  Token,
+  TOKEN_PROGRAM_ID,
+} from '@solana/spl-token'
+import { BN } from 'bn.js'
+
+const formReducer = (
+  state: PsyFinanceClaimUnderlyingPostExpiration,
+  action: Partial<PsyFinanceClaimUnderlyingPostExpiration>
+) => ({
+  ...state,
+  ...action,
+})
+
+const ClaimUnderlyingPostExpiration = ({
+  index,
+  governance,
+}: {
+  index: number
+  governance: ProgramAccount<Governance> | null
+}) => {
+  const { anchorProvider, connection, wallet } = useWallet()
+  const { governedTokenAccountsWithoutNfts } = useGovernanceAssets()
+  const { handleSetInstructions } = useContext(NewProposalContext)
+  const [options, setOptions] = useState<
+    AnchorProgramAccount<OptionMarket>[] | null
+  >(null)
+  const governedWriterTokenAccounts = useMemo(() => {
+    const _accounts: AssetAccount[] = []
+    options?.forEach((option) => {
+      const govWriterTokenAccount = governedTokenAccountsWithoutNfts.find(
+        (gAcct) =>
+          gAcct.extensions.token?.account.mint.equals(
+            option.account.writerTokenMint
+          )
+      )
+      if (govWriterTokenAccount) {
+        _accounts.push(govWriterTokenAccount)
+      }
+    })
+    return _accounts
+  }, [governedTokenAccountsWithoutNfts, options])
+
+  const [form, dispatch] = useReducer(formReducer, {
+    size: 0,
+    writerTokenAccount: undefined,
+    underlyingDestination: '',
+  })
+
+  const shouldBeGoverned = !!(index !== 0 && governance)
+
+  const getInstruction = async () => {
+    if (!form.size || !form.writerTokenAccount) {
+      throw new Error('Missing input(s)')
+    }
+    const program = new Program(
+      PsyAmericanIdl,
+      PSY_AMERICAN_PROGRAM_ID,
+      anchorProvider
+    )
+
+    const prerequisiteInstructions: TransactionInstruction[] = []
+
+    const optionAccount = options?.find((_option) =>
+      _option.account.writerTokenMint.equals(
+        form.writerTokenAccount?.extensions.token?.account.mint ??
+          PublicKey.default
+      )
+    )
+    if (!optionAccount) {
+      throw new Error('Invalid option from writer token account')
+    }
+
+    let underlyingDestination
+    if (form.underlyingDestination) {
+      underlyingDestination = new PublicKey(form.underlyingDestination ?? 0)
+    } else {
+      const { currentAddress, needToCreateAta } = await getATA({
+        connection,
+        receiverAddress: form.writerTokenAccount!.extensions.token!.account
+          .owner,
+        mintPK: optionAccount.account.underlyingAssetMint,
+        wallet,
+      })
+      if (needToCreateAta) {
+        prerequisiteInstructions.push(
+          Token.createAssociatedTokenAccountInstruction(
+            ASSOCIATED_TOKEN_PROGRAM_ID,
+            TOKEN_PROGRAM_ID,
+            optionAccount.account.underlyingAssetMint,
+            currentAddress,
+            form.writerTokenAccount!.extensions.token!.account.owner,
+            wallet?.publicKey as PublicKey
+          )
+        )
+      }
+      underlyingDestination = currentAddress
+    }
+
+    const ix = program.instruction.closePostExpiration(new BN(form.size), {
+      accounts: {
+        // @ts-ignore
+        userAuthority: program.provider.wallet.publicKey,
+        optionMarket: optionAccount.publicKey,
+        writerTokenMint: optionAccount.account.writerTokenMint,
+        writerTokenSrc: form.writerTokenAccount.extensions.token!.account
+          .address,
+        underlyingAssetPool: optionAccount.account.underlyingAssetPool,
+        underlyingAssetDest: underlyingDestination,
+        tokenProgram: TOKEN_PROGRAM_ID,
+        clock: SYSVAR_CLOCK_PUBKEY,
+      },
+    })
+
+    return {
+      serializedInstruction: serializeInstructionToBase64(ix),
+      isValid: true,
+      prerequisiteInstructions,
+      governance: form.writerTokenAccount?.governance,
+    }
+  }
+
+  useEffect(() => {
+    const program = new Program(
+      PsyAmericanIdl,
+      PSY_AMERICAN_PROGRAM_ID,
+      anchorProvider
+    )
+    ;(async () => {
+      const _options = (await program.account.optionMarket.all()) as
+        | AnchorProgramAccount<OptionMarket>[]
+        | null
+      setOptions(_options)
+    })()
+  }, [anchorProvider])
+
+  useEffect(() => {
+    handleSetInstructions(
+      { governedAccount: form.writerTokenAccount?.governance, getInstruction },
+      index
+    )
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [form, handleSetInstructions, index])
+
+  return (
+    <>
+      <GovernedAccountSelect
+        label="Writer Token source account"
+        governedAccounts={governedWriterTokenAccounts}
+        onChange={(value: AssetAccount) => {
+          dispatch({
+            writerTokenAccount: value,
+          })
+        }}
+        value={form.writerTokenAccount}
+        shouldBeGoverned={shouldBeGoverned}
+        governance={governance}
+        type="token"
+      />
+      <Input
+        label="Amount (must be integer)"
+        value={form.size}
+        type="number"
+        onChange={(event) =>
+          dispatch({
+            size: parseInt(event.target.value),
+          })
+        }
+      />
+
+      {/* Advanced configurations */}
+
+      <Tooltip content="Address the Underlying asset will be transferred to. Leaving empty will use (or create) a governed SPL token account for the tokens.">
+        <Input
+          label="(optional) Underlying destination address"
+          value={form.underlyingDestination}
+          onChange={(event) => {
+            dispatch({
+              underlyingDestination: event.target.value,
+            })
+          }}
+          type="string"
+        />
+      </Tooltip>
+    </>
+  )
+}
+
+export default ClaimUnderlyingPostExpiration

--- a/pages/dao/[symbol]/proposal/components/instructions/PsyFinance/ClaimUnderlyingPostExpiration.tsx
+++ b/pages/dao/[symbol]/proposal/components/instructions/PsyFinance/ClaimUnderlyingPostExpiration.tsx
@@ -127,8 +127,7 @@ const ClaimUnderlyingPostExpiration = ({
 
     const ix = program.instruction.closePostExpiration(new BN(form.size), {
       accounts: {
-        // @ts-ignore
-        userAuthority: program.provider.wallet.publicKey,
+        userAuthority: form.writerTokenAccount.extensions.token!.account.owner,
         optionMarket: optionAccount.publicKey,
         writerTokenMint: optionAccount.account.writerTokenMint,
         writerTokenSrc: form.writerTokenAccount.extensions.token!.account

--- a/pages/dao/[symbol]/proposal/components/instructions/PsyFinance/ExerciseOption.tsx
+++ b/pages/dao/[symbol]/proposal/components/instructions/PsyFinance/ExerciseOption.tsx
@@ -1,0 +1,194 @@
+import {
+  Governance,
+  ProgramAccount,
+  serializeInstructionToBase64,
+} from '@solana/spl-governance'
+import { PsyFinanceExerciseOption } from '@utils/uiTypes/proposalCreationTypes'
+import useWallet from '@hooks/useWallet'
+import { useContext, useEffect, useMemo, useReducer } from 'react'
+import { NewProposalContext } from '../../../new'
+import { AssetAccount } from '@utils/uiTypes/assets'
+import GovernedAccountSelect from '../../GovernedAccountSelect'
+import Input from '@components/inputs/Input'
+import { Program } from '@project-serum/anchor'
+import {
+  PsyAmericanIdl,
+  PSY_AMERICAN_PROGRAM_ID,
+  useGovernedOptionTokenAccounts,
+  useOptionAccounts,
+} from '@utils/instructions/PsyFinance'
+import { PublicKey, TransactionInstruction } from '@solana/web3.js'
+import { getATA } from '@utils/ataTools'
+import {
+  ASSOCIATED_TOKEN_PROGRAM_ID,
+  Token,
+  TOKEN_PROGRAM_ID,
+} from '@solana/spl-token'
+import { BN } from 'bn.js'
+import useGovernanceAssets from '@hooks/useGovernanceAssets'
+
+const formReducer = (
+  state: PsyFinanceExerciseOption,
+  action: Partial<PsyFinanceExerciseOption>
+) => ({
+  ...state,
+  ...action,
+})
+
+const ExerciseOption = ({
+  index,
+  governance,
+}: {
+  index: number
+  governance: ProgramAccount<Governance> | null
+}) => {
+  const { anchorProvider, connection, wallet } = useWallet()
+  const { handleSetInstructions } = useContext(NewProposalContext)
+  const options = useOptionAccounts()
+  const { governedTokenAccountsWithoutNfts } = useGovernanceAssets()
+  const governedOptionTokenAccounts = useGovernedOptionTokenAccounts(options)
+
+  const [form, dispatch] = useReducer(formReducer, {
+    size: 0,
+    optionTokenAccount: undefined,
+    quoteAssetAccount: undefined,
+  })
+  const selectedOptionAccount = useMemo(
+    () =>
+      options?.find((optionAcct) =>
+        optionAcct.account.optionMint.equals(
+          form.optionTokenAccount?.extensions.token?.account.mint ??
+            PublicKey.default
+        )
+      ),
+    [form.optionTokenAccount?.extensions.token?.account.mint, options]
+  )
+  const quoteAssetAccounts = useMemo(
+    () =>
+      governedTokenAccountsWithoutNfts.filter((govAcct) =>
+        govAcct.extensions.token?.account.mint.equals(
+          selectedOptionAccount?.account.quoteAssetMint ?? PublicKey.default
+        )
+      ),
+    [
+      governedTokenAccountsWithoutNfts,
+      selectedOptionAccount?.account.quoteAssetMint,
+    ]
+  )
+
+  const shouldBeGoverned = !!(index !== 0 && governance)
+
+  const getInstruction = async () => {
+    if (!form.size || !form.optionTokenAccount || !form.quoteAssetAccount) {
+      throw new Error('Missing input(s)')
+    }
+    const program = new Program(
+      PsyAmericanIdl,
+      PSY_AMERICAN_PROGRAM_ID,
+      anchorProvider
+    )
+
+    const prerequisiteInstructions: TransactionInstruction[] = []
+
+    if (!selectedOptionAccount) {
+      throw new Error('Invalid option from writer token account')
+    }
+
+    const {
+      currentAddress: underlyingDestination,
+      needToCreateAta,
+    } = await getATA({
+      connection,
+      receiverAddress: form.optionTokenAccount!.extensions.token!.account.owner,
+      mintPK: selectedOptionAccount.account.underlyingAssetMint,
+      wallet,
+    })
+    if (needToCreateAta) {
+      prerequisiteInstructions.push(
+        Token.createAssociatedTokenAccountInstruction(
+          ASSOCIATED_TOKEN_PROGRAM_ID,
+          TOKEN_PROGRAM_ID,
+          selectedOptionAccount.account.underlyingAssetMint,
+          underlyingDestination,
+          form.optionTokenAccount!.extensions.token!.account.owner,
+          wallet?.publicKey as PublicKey
+        )
+      )
+    }
+
+    const ix = program.instruction.exerciseOptionV2(new BN(form.size), {
+      accounts: {
+        userAuthority: form.optionTokenAccount.extensions.token!.account.owner,
+        optionAuthority: form.optionTokenAccount.extensions.token!.account
+          .owner,
+        optionMarket: selectedOptionAccount.publicKey,
+        optionMint: selectedOptionAccount.account.optionMint,
+        exerciserOptionTokenSrc: form.optionTokenAccount.extensions.token!
+          .account.address,
+        underlyingAssetPool: selectedOptionAccount.account.underlyingAssetPool,
+        underlyingAssetDest: underlyingDestination,
+        quoteAssetPool: selectedOptionAccount.account.quoteAssetPool,
+        quoteAssetSrc: form.quoteAssetAccount.extensions.token!.account.address,
+        tokenProgram: TOKEN_PROGRAM_ID,
+      },
+    })
+
+    return {
+      serializedInstruction: serializeInstructionToBase64(ix),
+      isValid: true,
+      prerequisiteInstructions,
+      governance: form.optionTokenAccount?.governance,
+    }
+  }
+
+  useEffect(() => {
+    handleSetInstructions(
+      { governedAccount: form.optionTokenAccount?.governance, getInstruction },
+      index
+    )
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [form, handleSetInstructions, index])
+
+  return (
+    <>
+      <GovernedAccountSelect
+        label="Option Token source account"
+        governedAccounts={governedOptionTokenAccounts}
+        onChange={(value: AssetAccount) => {
+          dispatch({
+            optionTokenAccount: value,
+          })
+        }}
+        value={form.optionTokenAccount}
+        shouldBeGoverned={shouldBeGoverned}
+        governance={governance}
+        type="token"
+      />
+      <GovernedAccountSelect
+        label="Quote Asset source account"
+        governedAccounts={quoteAssetAccounts}
+        onChange={(value: AssetAccount) => {
+          dispatch({
+            quoteAssetAccount: value,
+          })
+        }}
+        value={form.quoteAssetAccount}
+        shouldBeGoverned={shouldBeGoverned}
+        governance={governance}
+        type="token"
+      />
+      <Input
+        label="Amount (must be integer)"
+        value={form.size}
+        type="number"
+        onChange={(event) =>
+          dispatch({
+            size: parseInt(event.target.value),
+          })
+        }
+      />
+    </>
+  )
+}
+
+export default ExerciseOption

--- a/pages/dao/[symbol]/proposal/new.tsx
+++ b/pages/dao/[symbol]/proposal/new.tsx
@@ -137,6 +137,7 @@ import DualExercise from './components/instructions/Dual/DualExercise'
 import PsyFinanceMintAmericanOptions from './components/instructions/PsyFinance/MintAmericanOptions'
 import PsyFinanceBurnWriterTokenForQuote from './components/instructions/PsyFinance/BurnWriterTokenForQuote'
 import PsyFinanceClaimUnderlyingPostExpiration from './components/instructions/PsyFinance/ClaimUnderlyingPostExpiration'
+import PsyFinanceExerciseOption from './components/instructions/PsyFinance/ExerciseOption'
 
 const TITLE_LENGTH_LIMIT = 130
 
@@ -470,6 +471,7 @@ const New = () => {
       [Instructions.PsyFinanceMintAmericanOptions]: PsyFinanceMintAmericanOptions,
       [Instructions.PsyFinanceBurnWriterForQuote]: PsyFinanceBurnWriterTokenForQuote,
       [Instructions.PsyFinanceClaimUnderlyingPostExpiration]: PsyFinanceClaimUnderlyingPostExpiration,
+      [Instructions.PsyFinanceExerciseOption]: PsyFinanceExerciseOption,
       [Instructions.SwitchboardAdmitOracle]: SwitchboardAdmitOracle,
       [Instructions.SwitchboardRevokeOracle]: SwitchboardRevokeOracle,
       [Instructions.RefreshSolendObligation]: RefreshObligation,

--- a/pages/dao/[symbol]/proposal/new.tsx
+++ b/pages/dao/[symbol]/proposal/new.tsx
@@ -135,6 +135,7 @@ import RemoveServiceFromDID from './components/instructions/Identity/RemoveServi
 import DualWithdraw from './components/instructions/Dual/DualWithdraw'
 import DualExercise from './components/instructions/Dual/DualExercise'
 import PsyFinanceMintAmericanOptions from './components/instructions/PsyFinance/MintAmericanOptions'
+import PsyFinanceBurnWriterTokenForQuote from './components/instructions/PsyFinance/BurnWriterTokenForQuote'
 
 const TITLE_LENGTH_LIMIT = 130
 
@@ -466,6 +467,7 @@ const New = () => {
       [Instructions.DepositReserveLiquidityAndObligationCollateral]: DepositReserveLiquidityAndObligationCollateral,
       [Instructions.WithdrawObligationCollateralAndRedeemReserveLiquidity]: WithdrawObligationCollateralAndRedeemReserveLiquidity,
       [Instructions.PsyFinanceMintAmericanOptions]: PsyFinanceMintAmericanOptions,
+      [Instructions.PsyFinanceBurnWriterForQuote]: PsyFinanceBurnWriterTokenForQuote,
       [Instructions.SwitchboardAdmitOracle]: SwitchboardAdmitOracle,
       [Instructions.SwitchboardRevokeOracle]: SwitchboardRevokeOracle,
       [Instructions.RefreshSolendObligation]: RefreshObligation,

--- a/pages/dao/[symbol]/proposal/new.tsx
+++ b/pages/dao/[symbol]/proposal/new.tsx
@@ -136,6 +136,7 @@ import DualWithdraw from './components/instructions/Dual/DualWithdraw'
 import DualExercise from './components/instructions/Dual/DualExercise'
 import PsyFinanceMintAmericanOptions from './components/instructions/PsyFinance/MintAmericanOptions'
 import PsyFinanceBurnWriterTokenForQuote from './components/instructions/PsyFinance/BurnWriterTokenForQuote'
+import PsyFinanceClaimUnderlyingPostExpiration from './components/instructions/PsyFinance/ClaimUnderlyingPostExpiration'
 
 const TITLE_LENGTH_LIMIT = 130
 
@@ -468,6 +469,7 @@ const New = () => {
       [Instructions.WithdrawObligationCollateralAndRedeemReserveLiquidity]: WithdrawObligationCollateralAndRedeemReserveLiquidity,
       [Instructions.PsyFinanceMintAmericanOptions]: PsyFinanceMintAmericanOptions,
       [Instructions.PsyFinanceBurnWriterForQuote]: PsyFinanceBurnWriterTokenForQuote,
+      [Instructions.PsyFinanceClaimUnderlyingPostExpiration]: PsyFinanceClaimUnderlyingPostExpiration,
       [Instructions.SwitchboardAdmitOracle]: SwitchboardAdmitOracle,
       [Instructions.SwitchboardRevokeOracle]: SwitchboardRevokeOracle,
       [Instructions.RefreshSolendObligation]: RefreshObligation,

--- a/utils/instructions/PsyFinance/hooks.ts
+++ b/utils/instructions/PsyFinance/hooks.ts
@@ -58,3 +58,25 @@ export const useGovernedWriterTokenAccounts = (
     return _accounts
   }, [governedTokenAccountsWithoutNfts, options])
 }
+
+/**
+ * Governed accounts for option tokens only.
+ */
+export const useGovernedOptionTokenAccounts = (
+  options: AnchorProgramAccount<OptionMarket>[] | null
+) => {
+  const { governedTokenAccountsWithoutNfts } = useGovernanceAssets()
+  return useMemo(() => {
+    const _accounts: AssetAccount[] = []
+    options?.forEach((option) => {
+      const govOptionTokenAccount = governedTokenAccountsWithoutNfts.find(
+        (gAcct) =>
+          gAcct.extensions.token?.account.mint.equals(option.account.optionMint)
+      )
+      if (govOptionTokenAccount) {
+        _accounts.push(govOptionTokenAccount)
+      }
+    })
+    return _accounts
+  }, [governedTokenAccountsWithoutNfts, options])
+}

--- a/utils/instructions/PsyFinance/hooks.ts
+++ b/utils/instructions/PsyFinance/hooks.ts
@@ -1,0 +1,60 @@
+import {
+  Program,
+  ProgramAccount as AnchorProgramAccount,
+} from '@project-serum/anchor'
+import { useEffect, useMemo, useState } from 'react'
+import useWallet from '@hooks/useWallet'
+import { OptionMarket, PSY_AMERICAN_PROGRAM_ID } from './index'
+import { PsyAmericanIdl } from './PsyAmericanIdl'
+import useGovernanceAssets from '@hooks/useGovernanceAssets'
+import { AssetAccount } from '@utils/uiTypes/assets'
+
+/**
+ * Return entire list of PsyOption American options.
+ */
+export const useOptionAccounts = () => {
+  const { anchorProvider } = useWallet()
+  const [options, setOptions] = useState<
+    AnchorProgramAccount<OptionMarket>[] | null
+  >(null)
+
+  useEffect(() => {
+    const program = new Program(
+      PsyAmericanIdl,
+      PSY_AMERICAN_PROGRAM_ID,
+      anchorProvider
+    )
+    ;(async () => {
+      const _options = (await program.account.optionMarket.all()) as
+        | AnchorProgramAccount<OptionMarket>[]
+        | null
+      setOptions(_options)
+    })()
+  }, [anchorProvider])
+
+  return options
+}
+
+/**
+ * Governed accounts for writer tokens only.
+ */
+export const useGovernedWriterTokenAccounts = (
+  options: AnchorProgramAccount<OptionMarket>[] | null
+) => {
+  const { governedTokenAccountsWithoutNfts } = useGovernanceAssets()
+  return useMemo(() => {
+    const _accounts: AssetAccount[] = []
+    options?.forEach((option) => {
+      const govWriterTokenAccount = governedTokenAccountsWithoutNfts.find(
+        (gAcct) =>
+          gAcct.extensions.token?.account.mint.equals(
+            option.account.writerTokenMint
+          )
+      )
+      if (govWriterTokenAccount) {
+        _accounts.push(govWriterTokenAccount)
+      }
+    })
+    return _accounts
+  }, [governedTokenAccountsWithoutNfts, options])
+}

--- a/utils/instructions/PsyFinance/index.ts
+++ b/utils/instructions/PsyFinance/index.ts
@@ -16,6 +16,7 @@ import { PsyAmerican } from './PsyAmericanIdl'
 import { OptionMarket, OptionMarketWithKey } from './types'
 
 export { PsyAmericanIdl } from './PsyAmericanIdl'
+export * from './types'
 
 export const PSY_AMERICAN_PROGRAM_ID = new PublicKey(
   'R2y9ip6mxmWUj4pt54jP2hz2dgvMozy9VTSwMWE7evs'

--- a/utils/instructions/PsyFinance/index.ts
+++ b/utils/instructions/PsyFinance/index.ts
@@ -17,6 +17,7 @@ import { OptionMarket, OptionMarketWithKey } from './types'
 
 export { PsyAmericanIdl } from './PsyAmericanIdl'
 export * from './types'
+export * from './hooks'
 
 export const PSY_AMERICAN_PROGRAM_ID = new PublicKey(
   'R2y9ip6mxmWUj4pt54jP2hz2dgvMozy9VTSwMWE7evs'

--- a/utils/uiTypes/proposalCreationTypes.ts
+++ b/utils/uiTypes/proposalCreationTypes.ts
@@ -410,6 +410,12 @@ export interface PsyFinanceBurnWriterForQuote {
   quoteDestination: string
 }
 
+export interface PsyFinanceClaimUnderlyingPostExpiration {
+  size: number
+  writerTokenAccount: AssetAccount | undefined
+  underlyingDestination: string
+}
+
 export interface ForesightHasGovernedAccount {
   governedAccount: AssetAccount
 }
@@ -613,6 +619,7 @@ export enum Instructions {
   None,
   ProgramUpgrade,
   PsyFinanceBurnWriterForQuote,
+  PsyFinanceClaimUnderlyingPostExpiration,
   PsyFinanceMintAmericanOptions,
   RealmConfig,
   RefreshSolendObligation,

--- a/utils/uiTypes/proposalCreationTypes.ts
+++ b/utils/uiTypes/proposalCreationTypes.ts
@@ -404,6 +404,12 @@ export interface PsyFinanceMintAmericanOptionsForm {
   writerTokenDestinationAccount: string
 }
 
+export interface PsyFinanceBurnWriterForQuote {
+  size: number
+  writerTokenAccount: AssetAccount | undefined
+  quoteDestination: string
+}
+
 export interface ForesightHasGovernedAccount {
   governedAccount: AssetAccount
 }
@@ -606,6 +612,7 @@ export enum Instructions {
   Mint,
   None,
   ProgramUpgrade,
+  PsyFinanceBurnWriterForQuote,
   PsyFinanceMintAmericanOptions,
   RealmConfig,
   RefreshSolendObligation,

--- a/utils/uiTypes/proposalCreationTypes.ts
+++ b/utils/uiTypes/proposalCreationTypes.ts
@@ -392,6 +392,7 @@ export interface MangoMakeChangeReferralFeeParams2 {
   refMngoRequired2: number
 }
 
+/* PsyOptions American options */
 export interface PsyFinanceMintAmericanOptionsForm {
   contractSize: number
   expirationUnixTimestamp: number
@@ -415,6 +416,14 @@ export interface PsyFinanceClaimUnderlyingPostExpiration {
   writerTokenAccount: AssetAccount | undefined
   underlyingDestination: string
 }
+
+export interface PsyFinanceExerciseOption {
+  size: number
+  optionTokenAccount: AssetAccount | undefined
+  quoteAssetAccount: AssetAccount | undefined
+}
+
+/* End PsyOptions American options */
 
 export interface ForesightHasGovernedAccount {
   governedAccount: AssetAccount
@@ -620,6 +629,7 @@ export enum Instructions {
   ProgramUpgrade,
   PsyFinanceBurnWriterForQuote,
   PsyFinanceClaimUnderlyingPostExpiration,
+  PsyFinanceExerciseOption,
   PsyFinanceMintAmericanOptions,
   RealmConfig,
   RefreshSolendObligation,


### PR DESCRIPTION
PsyOptions American options support for:
- exercising options from DAO treasury
- claiming quote assets by burning writer token
- claiming underlying assets post expiration by burning writer token