### PR TITLE
feat: use domains as destination addresses

### DIFF
--- a/hooks/useDestination.ts
+++ b/hooks/useDestination.ts
@@ -1,0 +1,57 @@
+import { Connection, PublicKey } from '@solana/web3.js'
+import { tryParseDomain, tryParseKey } from '@tools/validators/pubkey'
+import { debounce } from '@utils/debounce'
+import {
+  TokenAccount,
+  TokenProgramAccount,
+  tryGetTokenAccount,
+} from '@utils/tokens'
+import { useEffect, useState } from 'react'
+
+const getDestination = async (connection: Connection, address: string) => {
+  let pubKey: PublicKey | null = null
+  let account: TokenProgramAccount<TokenAccount> | undefined = undefined
+
+  if (address?.trim().toLowerCase().endsWith('.sol')) {
+    pubKey = await tryParseDomain(address)
+  } else {
+    pubKey = tryParseKey(address)
+  }
+
+  if (pubKey) {
+    account = await tryGetTokenAccount(connection, pubKey)
+  }
+
+  return { pubKey, account }
+}
+
+export const useDestination = (connection: Connection, address: string) => {
+  const [destinationAddress, setDestinationAddress] = useState<PublicKey>()
+  const [destinationAccount, setDestinationAccount] = useState<
+    TokenProgramAccount<TokenAccount>
+  >()
+
+  useEffect(() => {
+    if (address) {
+      debounce.debounceFcn(async () => {
+        console.log('useDestination -> debounce', address)
+        const { pubKey, account } = await getDestination(connection, address)
+        console.log({ pubKey: pubKey?.toBase58(), account })
+
+        if (pubKey) {
+          setDestinationAddress(pubKey)
+        } else {
+          setDestinationAddress(undefined)
+        }
+
+        if (account) {
+          setDestinationAccount(account)
+        } else {
+          setDestinationAccount(undefined)
+        }
+      })
+    }
+  }, [connection, address])
+
+  return { destinationAccount, destinationAddress, setDestinationAddress }
+}

--- a/pages/dao/[symbol]/proposal/components/instructions/SplTokenTransfer.tsx
+++ b/pages/dao/[symbol]/proposal/components/instructions/SplTokenTransfer.tsx
@@ -1,19 +1,15 @@
 import React, { useContext, useEffect, useState } from 'react'
 import Input from '@components/inputs/Input'
 import useRealm from '@hooks/useRealm'
-import { AccountInfo } from '@solana/spl-token'
 import { getMintMinAmountAsDecimal } from '@tools/sdk/units'
 import { PublicKey } from '@solana/web3.js'
 import { precision } from '@utils/formatting'
-import { tryParseDomain, tryParseKey } from '@tools/validators/pubkey'
 import useWalletStore from 'stores/useWalletStore'
-import { TokenProgramAccount, tryGetTokenAccount } from '@utils/tokens'
 import {
   SplTokenTransferForm,
   UiInstruction,
 } from '@utils/uiTypes/proposalCreationTypes'
 import { getAccountName } from '@components/instructions/tools'
-import { debounce } from '@utils/debounce'
 import { NewProposalContext } from '../../new'
 import { getTokenTransferSchema } from '@utils/validations'
 import useGovernanceAssets from '@hooks/useGovernanceAssets'
@@ -24,6 +20,7 @@ import {
   getSolTransferInstruction,
   getTransferInstruction,
 } from '@utils/instructionTools'
+import { useDestination } from '@hooks/useDestination'
 
 const SplTokenTransfer = ({
   index,
@@ -46,20 +43,21 @@ const SplTokenTransfer = ({
     programId: programId?.toString(),
     mintInfo: undefined,
   })
+  const [address, setAddress] = useState('')
   const [governedAccount, setGovernedAccount] = useState<
     ProgramAccount<Governance> | undefined
   >(undefined)
-  const [
-    destinationAccount,
-    setDestinationAccount,
-  ] = useState<TokenProgramAccount<AccountInfo> | null>(null)
-  const [destinationAddress, setDestinationAddress] = useState('')
+  const { destinationAccount, destinationAddress } = useDestination(
+    connection.current,
+    address
+  )
   const [formErrors, setFormErrors] = useState({})
   const mintMinAmount = form.mintInfo
     ? getMintMinAmountAsDecimal(form.mintInfo)
     : 1
   const currentPrecision = precision(mintMinAmount)
   const { handleSetInstructions } = useContext(NewProposalContext)
+
   const handleSetForm = ({ propertyName, value }) => {
     setFormErrors({})
     setForm({ ...form, [propertyName]: value })
@@ -116,31 +114,14 @@ const SplTokenTransfer = ({
     })
     // eslint-disable-next-line react-hooks/exhaustive-deps -- TODO please fix, it can cause difficult bugs. You might wanna check out https://bobbyhadz.com/blog/react-hooks-exhaustive-deps for info. -@asktree
   }, [realmInfo?.programId])
+
   useEffect(() => {
     if (destinationAddress) {
-      debounce.debounceFcn(async () => {
-        let pubKey: PublicKey | null = null
-        if (destinationAddress.trim().toLowerCase().endsWith('.sol')) {
-          pubKey = await tryParseDomain(destinationAddress)
-        } else {
-          pubKey = tryParseKey(destinationAddress)
-        }
-
-        handleSetForm({
-          value: pubKey?.toBase58() ?? '',
-          propertyName: 'destinationAccount',
-        })
-
-        if (pubKey) {
-          const account = await tryGetTokenAccount(connection.current, pubKey)
-          setDestinationAccount(account ? account : null)
-        } else {
-          setDestinationAccount(null)
-        }
+      handleSetForm({
+        value: destinationAddress.toBase58(),
+        propertyName: 'destinationAccount',
       })
     } else {
-      setDestinationAccount(null)
-
       handleSetForm({
         value: '',
         propertyName: 'destinationAccount',
@@ -148,6 +129,7 @@ const SplTokenTransfer = ({
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps -- TODO please fix, it can cause difficult bugs. You might wanna check out https://bobbyhadz.com/blog/react-hooks-exhaustive-deps for info. -@asktree
   }, [destinationAddress])
+
   useEffect(() => {
     handleSetInstructions(
       { governedAccount: governedAccount, getInstruction },
@@ -163,7 +145,7 @@ const SplTokenTransfer = ({
   const destinationAccountName =
     destinationAccount?.publicKey &&
     getAccountName(destinationAccount?.account.address)
-  const base58DestinationAddress = destinationAddress.endsWith('.sol')
+  const base58DestinationAddress = address.endsWith('.sol')
     ? form.destinationAccount
     : undefined
   const schema = getTokenTransferSchema({ form, connection })
@@ -183,14 +165,14 @@ const SplTokenTransfer = ({
       ></GovernedAccountSelect>
       <Input
         label="Destination account"
-        value={destinationAddress}
+        value={address}
         type="text"
-        onChange={(evt) => setDestinationAddress(evt.target.value)}
+        onChange={(evt) => setAddress(evt.target.value)}
         error={formErrors['destinationAccount']}
       />
       {base58DestinationAddress && (
         <div>
-          <div className="pb-0.5 text-fgd-3 text-xs">{destinationAddress}</div>
+          <div className="pb-0.5 text-fgd-3 text-xs">{address}</div>
           <div className="text-xs">{base58DestinationAddress}</div>
         </div>
       )}

--- a/test/tools/validators/pubkey.test.ts
+++ b/test/tools/validators/pubkey.test.ts
@@ -1,0 +1,17 @@
+import { tryParseDomain } from '@tools/validators/pubkey'
+
+describe('Public Key Resolves ', () => {
+  const domain = 'carlos_0x.sol'
+  const tokenizedDomain = 'snakeoil.sol'
+  const pubkey = '9apnHjEQ8enLaPLxP7z9VQTphWE4nWqZcyHJYocQMpSE'
+
+  test('domains to publicKey', async () => {
+    const resolvedKey = await tryParseDomain(domain)
+    expect(resolvedKey?.toBase58()).toEqual(pubkey)
+  })
+
+  test('tokenized domains to publicKey', async () => {
+    const resolvedKey = await tryParseDomain(tokenizedDomain)
+    expect(resolvedKey?.toBase58()).toEqual(pubkey)
+  })
+})

--- a/tools/validators/pubkey.ts
+++ b/tools/validators/pubkey.ts
@@ -1,6 +1,10 @@
 import { coerce, instance, string } from 'superstruct'
 import { PublicKey } from '@solana/web3.js'
-import { getDomainKey, NameRegistryState } from '@bonfida/spl-name-service'
+import {
+  getDomainKey,
+  NameRegistryState,
+  // resolve,
+} from '@bonfida/spl-name-service'
 import { getConnectionContext } from '@utils/connection'
 
 export const PublicKeyFromString = coerce(
@@ -32,6 +36,13 @@ export const tryParseDomain = async (
       domainPDA
     )
 
+    console.log(`Class: ${registry.class.toBase58()}`)
+    console.log(`Data: ${registry.data?.toString()}`)
+    console.log(`Owner: ${registry.owner?.toBase58()}`)
+    console.log(`Parent: ${registry.parentName?.toBase58()}`)
+    console.log(`NFT Owner: ${nftOwner?.toBase58()}`)
+
+    // if domain is tokenized nftOwner should return the owner of it
     if (nftOwner) return nftOwner
 
     return registry.owner

--- a/tools/validators/pubkey.ts
+++ b/tools/validators/pubkey.ts
@@ -26,7 +26,6 @@ export const tryParseDomain = async (
 ): Promise<PublicKey | null> => {
   const { current: connection } = getConnectionContext('mainnet')
   try {
-    // pda
     const { pubkey: domainPDA } = await getDomainKey(
       domain.trim().toLowerCase()
     )
@@ -43,6 +42,10 @@ export const tryParseDomain = async (
     console.log(`NFT Owner: ${nftOwner?.toBase58()}`)
 
     // if domain is tokenized nftOwner should return the owner of it
+    // Test domain
+    // const domain = snakeoil.sol
+    // expected nftOwner = 9apnHjEQ8enLaPLxP7z9VQTphWE4nWqZcyHJYocQMpSE
+
     if (nftOwner) return nftOwner
 
     return registry.owner

--- a/tools/validators/pubkey.ts
+++ b/tools/validators/pubkey.ts
@@ -1,11 +1,17 @@
 import { coerce, instance, string } from 'superstruct'
-import { PublicKey } from '@solana/web3.js'
 import {
-  getDomainKey,
-  NameRegistryState,
-  // resolve,
-} from '@bonfida/spl-name-service'
+  Connection,
+  GetProgramAccountsFilter,
+  PublicKey,
+} from '@solana/web3.js'
+
 import { getConnectionContext } from '@utils/connection'
+import {
+  MINT_PREFIX,
+  NAME_TOKENIZER_ID,
+  resolve,
+} from '@bonfida/spl-name-service'
+import { TOKEN_PROGRAM_ID } from '@solana/spl-token'
 
 export const PublicKeyFromString = coerce(
   instance(PublicKey),
@@ -26,25 +32,11 @@ export const tryParseDomain = async (
 ): Promise<PublicKey | null> => {
   const { current: connection } = getConnectionContext('mainnet')
   try {
-    const { pubkey: domainPDA } = await getDomainKey(
-      domain.trim().toLowerCase()
-    )
+    const publicKey = await resolve(connection, domain.toLowerCase().trim())
 
-    const { nftOwner, registry } = await NameRegistryState.retrieve(
-      connection,
-      domainPDA
-    )
-
-    // console.log(`Class: ${registry.class.toBase58()}`)
-    // console.log(`Data: ${registry.data?.toString()}`)
-    // console.log(`Owner: ${registry.owner?.toBase58()}`)
-    // console.log(`Parent: ${registry.parentName?.toBase58()}`)
-    // console.log(`NFT Owner: ${nftOwner?.toBase58()}`)
-
-    if (nftOwner) return nftOwner
-
-    return registry.owner
+    return publicKey
   } catch (error) {
+    console.log('🚀 ~ file: pubkey.ts:32 ~ error', error)
     return null
   }
 }

--- a/tools/validators/pubkey.ts
+++ b/tools/validators/pubkey.ts
@@ -1,17 +1,8 @@
 import { coerce, instance, string } from 'superstruct'
-import {
-  Connection,
-  GetProgramAccountsFilter,
-  PublicKey,
-} from '@solana/web3.js'
+import { PublicKey } from '@solana/web3.js'
 
 import { getConnectionContext } from '@utils/connection'
-import {
-  MINT_PREFIX,
-  NAME_TOKENIZER_ID,
-  resolve,
-} from '@bonfida/spl-name-service'
-import { TOKEN_PROGRAM_ID } from '@solana/spl-token'
+import { resolveDomain } from '@utils/domains'
 
 export const PublicKeyFromString = coerce(
   instance(PublicKey),
@@ -32,9 +23,12 @@ export const tryParseDomain = async (
 ): Promise<PublicKey | null> => {
   const { current: connection } = getConnectionContext('mainnet')
   try {
-    const publicKey = await resolve(connection, domain.toLowerCase().trim())
+    const publicKey = await resolveDomain(
+      connection,
+      domain.toLowerCase().trim()
+    )
 
-    return publicKey
+    return publicKey ?? null
   } catch (error) {
     console.log('🚀 ~ file: pubkey.ts:32 ~ error', error)
     return null

--- a/tools/validators/pubkey.ts
+++ b/tools/validators/pubkey.ts
@@ -30,7 +30,6 @@ export const tryParseDomain = async (
 
     return publicKey ?? null
   } catch (error) {
-    console.log('🚀 ~ file: pubkey.ts:32 ~ error', error)
     return null
   }
 }

--- a/tools/validators/pubkey.ts
+++ b/tools/validators/pubkey.ts
@@ -35,16 +35,11 @@ export const tryParseDomain = async (
       domainPDA
     )
 
-    console.log(`Class: ${registry.class.toBase58()}`)
-    console.log(`Data: ${registry.data?.toString()}`)
-    console.log(`Owner: ${registry.owner?.toBase58()}`)
-    console.log(`Parent: ${registry.parentName?.toBase58()}`)
-    console.log(`NFT Owner: ${nftOwner?.toBase58()}`)
-
-    // if domain is tokenized nftOwner should return the owner of it
-    // Test domain
-    // const domain = snakeoil.sol
-    // expected nftOwner = 9apnHjEQ8enLaPLxP7z9VQTphWE4nWqZcyHJYocQMpSE
+    // console.log(`Class: ${registry.class.toBase58()}`)
+    // console.log(`Data: ${registry.data?.toString()}`)
+    // console.log(`Owner: ${registry.owner?.toBase58()}`)
+    // console.log(`Parent: ${registry.parentName?.toBase58()}`)
+    // console.log(`NFT Owner: ${nftOwner?.toBase58()}`)
 
     if (nftOwner) return nftOwner
 

--- a/tools/validators/pubkey.ts
+++ b/tools/validators/pubkey.ts
@@ -1,5 +1,7 @@
 import { coerce, instance, string } from 'superstruct'
 import { PublicKey } from '@solana/web3.js'
+import { getDomainKey, NameRegistryState } from '@bonfida/spl-name-service'
+import { getConnectionContext } from '@utils/connection'
 
 export const PublicKeyFromString = coerce(
   instance(PublicKey),
@@ -10,6 +12,29 @@ export const PublicKeyFromString = coerce(
 export const tryParseKey = (key: string): PublicKey | null => {
   try {
     return new PublicKey(key)
+  } catch (error) {
+    return null
+  }
+}
+
+export const tryParseDomain = async (
+  domain: string
+): Promise<PublicKey | null> => {
+  const { current: connection } = getConnectionContext('mainnet')
+  try {
+    // pda
+    const { pubkey: domainPDA } = await getDomainKey(
+      domain.trim().toLowerCase()
+    )
+
+    const { nftOwner, registry } = await NameRegistryState.retrieve(
+      connection,
+      domainPDA
+    )
+
+    if (nftOwner) return nftOwner
+
+    return registry.owner
   } catch (error) {
     return null
   }

--- a/utils/domains.ts
+++ b/utils/domains.ts
@@ -1,0 +1,59 @@
+import {
+  getDomainKey,
+  MINT_PREFIX,
+  NameRegistryState,
+  NAME_TOKENIZER_ID,
+} from '@bonfida/spl-name-service'
+import { Connection, ParsedAccountData, PublicKey } from '@solana/web3.js'
+
+export const resolveDomain = async (
+  connection: Connection,
+  domainName: string
+) => {
+  try {
+    // Get the public key for the domain
+    const { pubkey } = await getDomainKey(domainName.replace('.sol', ''))
+
+    // Check if the domain is an NFT
+    const [nftMintAddress] = await PublicKey.findProgramAddress(
+      [MINT_PREFIX, pubkey.toBuffer()],
+      NAME_TOKENIZER_ID
+    )
+
+    const nftAccountData = await connection.getParsedAccountInfo(nftMintAddress)
+
+    if (
+      nftAccountData.value?.data &&
+      !Buffer.isBuffer(nftAccountData.value.data)
+    ) {
+      const parsedData: ParsedAccountData = nftAccountData.value.data
+
+      if (
+        parsedData.parsed.info.supply === '1' &&
+        parsedData.parsed.info.isInitialized
+      ) {
+        const { value } = await connection.getTokenLargestAccounts(
+          nftMintAddress
+        )
+        const nftHolder = value.find((e) => e.amount === '1')?.address
+
+        if (!nftHolder) return undefined
+
+        const holderInfo = await connection.getAccountInfo(nftHolder)
+
+        if (!holderInfo || !holderInfo.data) {
+          return undefined
+        }
+
+        return new PublicKey(holderInfo.data.slice(32, 64))
+      }
+    }
+
+    // Retrieve the domain's registry information
+    const { registry } = await NameRegistryState.retrieve(connection, pubkey)
+
+    return registry.owner
+  } catch (error) {
+    return undefined
+  }
+}

--- a/utils/validations.tsx
+++ b/utils/validations.tsx
@@ -780,7 +780,7 @@ export const getMintSchema = ({ form, connection }) => {
             }
           } else {
             return this.createError({
-              message: `Destination account is required`,
+              message: `Invalid destination account`,
             })
           }
         }


### PR DESCRIPTION
Enables '.sol' domains as destinations for Mint and Transfer instructions

https://user-images.githubusercontent.com/75177443/213294316-fcc49702-af92-4a37-858f-788b66cc3a43.mp4


