### PR TITLE
Wizards deposit council tokens directly to DAO

### DIFF
--- a/hub/providers/WalletSelector/index.tsx
+++ b/hub/providers/WalletSelector/index.tsx
@@ -107,6 +107,7 @@ function WalletSelectorInner(props: Props) {
   const adapters = wallets.filter(
     (adapter) =>
       adapter.readyState === WalletReadyState.Installed ||
+      adapter.readyState === WalletReadyState.NotDetected ||
       adapter.readyState === WalletReadyState.Loadable,
   );
 
@@ -131,7 +132,7 @@ function WalletSelectorInner(props: Props) {
       >
         <Dialog.Portal>
           <Dialog.Overlay>
-            <Dialog.Content className={cx('max-h-[410px]', 'w-[375px]')}>
+            <Dialog.Content className="w-[375px]">
               <Dialog.Close />
               <div
                 className={cx(

--- a/tools/governance/prepareRealmCreation.ts
+++ b/tools/governance/prepareRealmCreation.ts
@@ -188,24 +188,16 @@ export async function prepareRealmCreation({
   // Create council mint
   let councilMintPk
 
-  // TODO explain the circumstances under which this set of conditions would be true
   if (
     zeroCommunityTokenSupply &&
     zeroCouncilTokenSupply &&
     nftCollectionCount === 0 &&
     councilWalletPks.length === 0
   ) {
-    councilWalletPks.push(wallet.publicKey as PublicKey)
-    councilMintPk = await withCreateMint(
-      connection,
-      mintsSetupInstructions,
-      mintsSetupSigners,
-      walletPk,
-      null,
-      0,
-      walletPk
-    )
-  } else if (!existingCouncilMintPk && createCouncil) {
+    throw new Error('no tokens exist that could govern this DAO')
+  }
+
+  if (!existingCouncilMintPk && createCouncil) {
     councilMintPk = await withCreateMint(
       connection,
       mintsSetupInstructions,

--- a/tools/governance/prepareRealmCreation.ts
+++ b/tools/governance/prepareRealmCreation.ts
@@ -253,7 +253,7 @@ export async function prepareRealmCreation({
         realmPk,
         councilMintPk,
         councilMintPk,
-        walletPk,
+        teamWalletPk,
         walletPk,
         walletPk,
         new BN(initialCouncilTokenAmount)


### PR DESCRIPTION
Previously the wizards still used the old way of adding members: mint tokens to them and then they can deposit. This PR makes the wizards instead deposit council membership tokens directly into DAO, a v3 feature. 

Example DAO using this PR: http://localhost:3000/dao/3eT6tChqwZS67cXj1giWXXYDaJ7Pxm8Qr5oEWYYVgDum?cluster=devnet