### PR TITLE
quickie: fix incorrect warnings

### DIFF
--- a/pages/dao/[symbol]/proposal/[pk]/ProposalWarnings.tsx
+++ b/pages/dao/[symbol]/proposal/[pk]/ProposalWarnings.tsx
@@ -91,7 +91,7 @@ const useProposalSafetyCheck = () => {
     )
 
     const realmConfigWarnings = ixs.map((ix) => {
-      if (realm?.owner.equals(ix.programId) && ix.data[0] === 19) {
+      if (ix.programId.equals(realmInfo.programId) && ix.data[0] === 19) {
         return 'setGovernanceConfig'
       }
       if (ix.programId.equals(realmInfo.programId) && ix.data[0] === 22) {
@@ -102,7 +102,11 @@ const useProposalSafetyCheck = () => {
           (a) => a.isWritable && a.pubkey.equals(config.pubkey)
         ) !== undefined
       ) {
-        return 'ThirdPartyInstructionWritesConfig'
+        if (ix.programId.equals(realmInfo.programId)) {
+          return 'setRealmConfig'
+        } else {
+          return 'ThirdPartyInstructionWritesConfig'
+        }
       }
     })
 

--- a/pages/dao/[symbol]/proposal/[pk]/ProposalWarnings.tsx
+++ b/pages/dao/[symbol]/proposal/[pk]/ProposalWarnings.tsx
@@ -81,7 +81,7 @@ const SetGovernanceConfig = () => (
 )
 
 const useProposalSafetyCheck = () => {
-  const { config, realmInfo, realm } = useRealm()
+  const { config, realmInfo } = useRealm()
   const { instructions } = useProposal()
   const realmConfigWarnings = useMemo(() => {
     if (realmInfo === undefined || config === undefined) return undefined


### PR DESCRIPTION
Previously if instructions in a proposal wrote to realm config but weren't on a white list, users would be warned that a third party instruction is being used. Now this message only shows if the governance program is not the programId of the instruction (though another warning will still show)