### PR TITLE
quickie: key queries on cluster

### DIFF
--- a/components/VoteCommentModal.tsx
+++ b/components/VoteCommentModal.tsx
@@ -78,7 +78,9 @@ const useSubmitVote = ({
     const confirmationCallback = async () => {
       await refetchProposals()
       // TODO refine this to only invalidate the one query
-      await queryClient.invalidateQueries(voteRecordQueryKeys.all)
+      await queryClient.invalidateQueries(
+        voteRecordQueryKeys.all(connection.cluster)
+      )
     }
 
     try {


### PR DESCRIPTION
It's important to key queries on the cluster, so that they get refetched if the user switches cluster. I had neglected to do this in one of my queries, so I fix that here.