### PR TITLE
quickie: escape meaningless math

### DIFF
--- a/components/ProposalCard.tsx
+++ b/components/ProposalCard.tsx
@@ -77,7 +77,7 @@ const ProposalCard = ({ proposalPk, proposal }: ProposalCardProps) => {
                 votesData._programVersion !== 1 &&
                 votesData._programVersion !== 2 &&
                 votesData.veto !== undefined &&
-                votesData.veto.voteProgress > 0 ? (
+                (votesData.veto.voteProgress ?? 0) > 0 ? (
                   <>
                     <div className="border-r border-fgd-4 hidden lg:block" />
 

--- a/components/ProposalSelectCard.tsx
+++ b/components/ProposalSelectCard.tsx
@@ -82,7 +82,7 @@ const ProposalSelectCard = ({
           votesData._programVersion !== 1 &&
           votesData._programVersion !== 2 &&
           votesData.veto !== undefined &&
-          votesData.veto.voteProgress > 0 ? (
+          (votesData.veto.voteProgress ?? 0) > 0 ? (
             <>
               <div className="border-r border-fgd-4 hidden lg:block" />
               <div className="w-full lg:w-auto flex-1">

--- a/hooks/useProposalVotes.tsx
+++ b/hooks/useProposalVotes.tsx
@@ -139,9 +139,7 @@ export default function useProposalVotes(proposal?: Proposal) {
     vetoMintInfo.decimals
   )
   // its impossible to accurately know the veto votes required for a finalized, non-vetoed proposal
-  const finalizedAndNotVetoed =
-    proposal.isVoteFinalized() && proposal.state !== ProposalState.Vetoed
-  if (finalizedAndNotVetoed)
+  if (proposal.isVoteFinalized() && proposal.state !== ProposalState.Vetoed)
     return {
       _programVersion: programVersion,
       ...results,

--- a/hooks/useProposalVotes.tsx
+++ b/hooks/useProposalVotes.tsx
@@ -1,5 +1,5 @@
 import { BN } from '@project-serum/anchor'
-import { Proposal } from '@solana/spl-governance'
+import { Proposal, ProposalState } from '@solana/spl-governance'
 import useNftPluginStore from 'NftVotePlugin/store/nftPluginStore'
 import { getProposalMaxVoteWeight } from '../models/voteWeights'
 import { calculatePct, fmtTokenAmount } from '../utils/formatting'
@@ -134,8 +134,25 @@ export default function useProposalVotes(proposal?: Proposal) {
       veto: undefined,
     }
 
-  const isPluginCommunityVeto = maxVoteRecord && !isCommunityVote
+  const vetoVoteCount = fmtTokenAmount(
+    proposal.vetoVoteWeight,
+    vetoMintInfo.decimals
+  )
+  // its impossible to accurately know the veto votes required for a finalized, non-vetoed proposal
+  const finalizedAndNotVetoed =
+    proposal.isVoteFinalized() && proposal.state !== ProposalState.Vetoed
+  if (finalizedAndNotVetoed)
+    return {
+      _programVersion: programVersion,
+      ...results,
+      veto: {
+        votesRequired: undefined,
+        voteCount: vetoVoteCount,
+        voteProgress: undefined,
+      },
+    }
 
+  const isPluginCommunityVeto = maxVoteRecord && !isCommunityVote
   const vetoMaxVoteWeight = isPluginCommunityVeto
     ? maxVoteRecord.account.maxVoterWeight
     : getProposalMaxVoteWeight(
@@ -144,11 +161,6 @@ export default function useProposalVotes(proposal?: Proposal) {
         vetoMintInfo,
         vetoMintPk
       )
-
-  const vetoVoteCount = fmtTokenAmount(
-    proposal.vetoVoteWeight,
-    vetoMintInfo.decimals
-  )
 
   const vetoVoteProgress = calculatePct(
     proposal.vetoVoteWeight,

--- a/pages/dao/[symbol]/proposal/[pk]/index.tsx
+++ b/pages/dao/[symbol]/proposal/[pk]/index.tsx
@@ -151,7 +151,7 @@ const Proposal = () => {
                   voteData._programVersion !== 1 &&
                   voteData._programVersion !== 2 &&
                   voteData.veto !== undefined &&
-                  voteData.veto.voteProgress > 0 ? (
+                  (voteData.veto.voteProgress ?? 0) > 0 ? (
                     <div className="pb-3">
                       <VetoProgress
                         votesRequired={voteData.veto.votesRequired}


### PR DESCRIPTION
Rather than have a hook do bogus math on veto progress in a finalized proposal, when in fact we can't compute it, just return undefined.