### PR TITLE
disable execution button if user cant execute this proposal

### DIFF
--- a/actions/executeInstructions.ts
+++ b/actions/executeInstructions.ts
@@ -55,6 +55,17 @@ export const executeInstructions = async (
       }
     })
 
+    console.log(
+      'txes',
+      txes,
+      txes.map((x) =>
+        x.instructionsSet.map((x) =>
+          x.transactionInstruction.keys
+            .filter((x) => x.isSigner)
+            .map((x) => x.pubkey.toString())
+        )
+      )
+    )
     await sendTransactionsV3({
       connection,
       wallet,

--- a/components/instructions/ExecuteAllInstructionButton.tsx
+++ b/components/instructions/ExecuteAllInstructionButton.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useMemo, useState } from 'react'
+import React, { useEffect, useState } from 'react'
 import {
   InstructionExecutionStatus,
   ProgramAccount,

--- a/components/instructions/ExecuteAllInstructionButton.tsx
+++ b/components/instructions/ExecuteAllInstructionButton.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react'
+import React, { useEffect, useMemo, useState } from 'react'
 import {
   InstructionExecutionStatus,
   ProgramAccount,
@@ -6,8 +6,9 @@ import {
   ProposalState,
   ProposalTransaction,
   RpcContext,
+  withExecuteTransaction,
 } from '@solana/spl-governance'
-import { PublicKey } from '@solana/web3.js'
+import { PublicKey, TransactionInstruction } from '@solana/web3.js'
 import { CheckCircleIcon, PlayIcon, RefreshIcon } from '@heroicons/react/solid'
 import Button from '@components/Button'
 import Tooltip from '@components/Tooltip'
@@ -16,12 +17,64 @@ import { getProgramVersionForRealm } from '@models/registry/api'
 import { executeInstructions } from 'actions/executeInstructions'
 import useWalletStore from 'stores/useWalletStore'
 import { notify } from '@utils/notifications'
+import useProgramVersion from '@hooks/useProgramVersion'
+import { abbreviateAddress } from '@utils/formatting'
 
 export enum PlayState {
   Played,
   Unplayed,
   Playing,
   Error,
+}
+
+const useSignersNeeded = (
+  proposalInstructions: ProgramAccount<ProposalTransaction>[],
+  proposal: ProgramAccount<Proposal>
+) => {
+  const { realm } = useRealm()
+  const programVersion = useProgramVersion()
+
+  const [signersNeeded, setSignersNeeded] = useState<PublicKey[]>()
+
+  useEffect(() => {
+    const x = async () => {
+      console.log('i ran the check')
+
+      if (realm?.owner === undefined) return undefined
+
+      const executionInstructions: TransactionInstruction[] = []
+
+      await Promise.all(
+        proposalInstructions.map((instruction) =>
+          // withExecuteTransaction function mutates 'executionInstructions'
+          withExecuteTransaction(
+            executionInstructions,
+            realm.owner,
+            programVersion,
+            proposal.account.governance,
+            proposal.pubkey,
+            instruction.pubkey,
+            [instruction.account.getSingleInstruction()]
+          )
+        )
+      )
+
+      const signers = executionInstructions
+        .flatMap((x) => x.keys)
+        .filter((x) => x.isSigner)
+        .map((x) => x.pubkey)
+      setSignersNeeded(signers)
+    }
+    x()
+  }, [
+    programVersion,
+    proposal.account.governance,
+    proposal.pubkey,
+    proposalInstructions,
+    realm?.owner,
+  ])
+
+  return signersNeeded
 }
 
 export function ExecuteAllInstructionButton({
@@ -79,6 +132,14 @@ export function ExecuteAllInstructionButton({
     // eslint-disable-next-line react-hooks/exhaustive-deps -- TODO please fix, it can cause difficult bugs. You might wanna check out https://bobbyhadz.com/blog/react-hooks-exhaustive-deps for info. -@asktree
   }, [isPassedExecutionSlot, rpcContext.connection, currentSlot])
 
+  const signersNeeded = useSignersNeeded(proposalInstructions, proposal)
+  const otherSignerNeeded =
+    signersNeeded === undefined
+      ? undefined
+      : signersNeeded.filter(
+          (x) => !wallet?.publicKey || !x.equals(wallet?.publicKey)
+        ).length > 0
+
   const onExecuteInstructions = async () => {
     setPlaying(PlayState.Playing)
 
@@ -126,8 +187,15 @@ export function ExecuteAllInstructionButton({
       <Button
         className={className}
         small={small ?? true}
-        disabled={!connected}
+        disabled={!connected || otherSignerNeeded}
         onClick={onExecuteInstructions}
+        tooltipMessage={
+          otherSignerNeeded && signersNeeded !== undefined
+            ? `This proposal must be executed by ${abbreviateAddress(
+                signersNeeded[0]
+              )}`
+            : undefined
+        }
       >
         {label}
         {proposalInstructions.length > 1

--- a/components/instructions/programs/governance.tsx
+++ b/components/instructions/programs/governance.tsx
@@ -2,6 +2,7 @@ import Loading from '@components/Loading'
 import { fetchMintInfoByPubkey } from '@hooks/queries/mintInfo'
 import {
   AccountMetaData,
+  DepositGoverningTokensArgs,
   deserializeBorsh,
   getGovernance,
   getGovernanceInstructionSchema,
@@ -39,6 +40,70 @@ const governanceProgramId = 'GovER5Lthms3bLBqWub97yVrMmEogzX7xNjdXpPPCVZw'
 
 export const GOVERNANCE_INSTRUCTIONS = {
   [governanceProgramId]: {
+    1: {
+      /// Deposits governing tokens (Community or Council) to Governance Realm and establishes your voter weight to be used for voting within the Realm
+      /// Note: If subsequent (top up) deposit is made and there are active votes for the Voter then the vote weights won't be updated automatically
+      /// It can be done by relinquishing votes on active Proposals and voting again with the new weight
+      ///
+      ///  0. `[]` Realm account
+      ///  1. `[writable]` Governing Token Holding account. PDA seeds: ['governance',realm, governing_token_mint]
+      ///  2. `[writable]` Governing Token Source account. It can be either spl-token TokenAccount or MintAccount
+      ///      Tokens will be transferred or minted to the Holding account
+      ///  3. `[signer]` Governing Token Owner account
+      ///  4. `[signer]` Governing Token Source account authority
+      ///      It should be owner for TokenAccount and mint_authority for MintAccount
+      ///  5. `[writable]` TokenOwnerRecord account. PDA seeds: ['governance',realm, governing_token_mint, governing_token_owner]
+      ///  6. `[signer]` Payer
+      ///  7. `[]` System
+      ///  8. `[]` SPL Token program
+      ///  9. `[]` RealmConfig account. PDA seeds: ['realm-config', realm]
+      name: 'Deposit Governing Tokens',
+      accounts: [
+        { name: 'Realm' },
+        { name: 'Governing Token Holding' },
+        { name: 'Mint' },
+        { name: 'Governing Token Owner' },
+        { name: 'Mint Authority' },
+        { name: 'Token Owner Record' },
+        { name: 'Payer' },
+        { name: 'System' },
+        { name: 'SPL Token Program' },
+        { name: 'Realm Config' },
+      ],
+      getDataUI: async (
+        connection: Connection,
+        data: Uint8Array,
+        accounts: AccountMetaData[]
+      ) => {
+        const realm = await getRealm(connection, accounts[0].pubkey)
+        const programVersion = await getGovernanceProgramVersion(
+          connection,
+          realm.owner
+        )
+        const mintInfoQuery = await fetchMintInfoByPubkey(
+          connection,
+          accounts[2].pubkey
+        )
+
+        const args = deserializeBorsh(
+          getGovernanceInstructionSchema(programVersion),
+          DepositGoverningTokensArgs,
+          Buffer.from(data)
+        ) as DepositGoverningTokensArgs
+
+        return (
+          <>
+            <p>
+              amount:{' '}
+              {mintInfoQuery.result !== undefined
+                ? fmtBnMintDecimals(args.amount, mintInfoQuery.result.decimals)
+                : 'loading mint info...'}{' '}
+              ({args.amount.toString()})
+            </p>
+          </>
+        )
+      },
+    },
     19: {
       name: 'Set Governance Config',
       accounts: [{ name: 'Governance' }],


### PR DESCRIPTION
This PR fulfills a request by @SebastianBor to disable the Execute button for proposals if the user can't actually execute the proposal.

It looks like this: 
<img width="1193" alt="image" src="https://user-images.githubusercontent.com/12001874/218285926-94558707-9fb0-4627-b555-09e277e7c64f.png">

The way I implemented this was by getting the actual transation to be sent, and checking the signers. So it is ground truth (as opposed to checking the proposal's contents for accounts that aren't part of the DAO).