### PR TITLE
Update dual finance airdrop

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "@coral-xyz/borsh": "0.26.0",
     "@dialectlabs/react-sdk-blockchain-solana": "1.0.0-beta.3",
     "@dialectlabs/react-ui": "1.1.0-beta.5",
-    "@dual-finance/airdrop": "0.0.4",
+    "@dual-finance/airdrop": "0.0.7",
     "@dual-finance/staking-options": "0.0.17",
     "@emotion/react": "11.9.0",
     "@emotion/styled": "11.8.1",

--- a/utils/instructions/Dual/airdrop.ts
+++ b/utils/instructions/Dual/airdrop.ts
@@ -10,7 +10,6 @@ import {
 } from '@utils/uiTypes/proposalCreationTypes'
 import { WalletAdapter } from '@solana/wallet-adapter-base'
 import { Airdrop, AirdropConfigureContext } from '@dual-finance/airdrop'
-import { Keypair } from '@solana/web3.js'
 import { BN } from '@coral-xyz/anchor'
 import { getMintNaturalAmountFromDecimalAsBN } from '@tools/sdk/units'
 
@@ -65,7 +64,6 @@ export async function getAirdropInstruction({
     return {
       serializedInstruction,
       additionalSerializedInstructions,
-      signers: airdropTransactionContext.signers as Keypair[],
       isValid: true,
       governance: form.treasury?.governance,
     }

--- a/yarn.lock
+++ b/yarn.lock
@@ -873,10 +873,10 @@
     js-sha256 "^0.9.0"
     tweetnacl "1.0.3"
 
-"@dual-finance/airdrop@0.0.4":
-  version "0.0.4"
-  resolved "https://registry.yarnpkg.com/@dual-finance/airdrop/-/airdrop-0.0.4.tgz#12ee6f1a99f52725eaa783c522efd7021981db3c"
-  integrity sha512-eLBC1pzJwqhniVvHm3b26RWcLEVcFRL3OA94FsagUiWzSY7uYLigo5phBvN153dviaI+AiNPc86aQ85IlY+AAA==
+"@dual-finance/airdrop@0.0.7":
+  version "0.0.7"
+  resolved "https://registry.yarnpkg.com/@dual-finance/airdrop/-/airdrop-0.0.7.tgz#564d4a013a0ddeb804510a776b04ec67d57d2abc"
+  integrity sha512-iAaPnGzoaEdRJJEZT4nS6MWchrb5cw1drNRfsUUEvvQwuw4SPvRcYVaWwWvTRcbAJK0ll0eQBkGLUbsywfHQpQ==
   dependencies:
     "@coral-xyz/anchor" "^0.26.0"
     "@solana/spl-token" "^0.3.6"
@@ -5021,7 +5021,7 @@
     "@wallet-standard/app" "^1.0.0"
     "@wallet-standard/base" "^1.0.0"
 
-"@solana/web3.js@1.42.0", "@solana/web3.js@1.56.0", "@solana/web3.js@1.66.2", "@solana/web3.js@^1.16.1", "@solana/web3.js@^1.17.0", "@solana/web3.js@^1.20.0", "@solana/web3.js@^1.21.0", "@solana/web3.js@^1.22.0", "@solana/web3.js@^1.24.1", "@solana/web3.js@^1.29.2", "@solana/web3.js@^1.30.2", "@solana/web3.js@^1.31.0", "@solana/web3.js@^1.32.0", "@solana/web3.js@^1.35.0", "@solana/web3.js@^1.35.1", "@solana/web3.js@^1.36.0", "@solana/web3.js@^1.37.1", "@solana/web3.js@^1.42.0", "@solana/web3.js@^1.43.5", "@solana/web3.js@^1.44.3", "@solana/web3.js@^1.48.0", "@solana/web3.js@^1.56.2", "@solana/web3.js@^1.59.1", "@solana/web3.js@^1.63.0", "@solana/web3.js@^1.63.1", "@solana/web3.js@^1.66.2", "@solana/web3.js@^1.68.0", "@solana/web3.js@^1.73.2":
+"@solana/web3.js@1.42.0", "@solana/web3.js@1.56.0", "@solana/web3.js@1.66.2", "@solana/web3.js@^1.16.1", "@solana/web3.js@^1.17.0", "@solana/web3.js@^1.20.0", "@solana/web3.js@^1.21.0", "@solana/web3.js@^1.22.0", "@solana/web3.js@^1.24.1", "@solana/web3.js@^1.29.2", "@solana/web3.js@^1.30.2", "@solana/web3.js@^1.31.0", "@solana/web3.js@^1.32.0", "@solana/web3.js@^1.35.0", "@solana/web3.js@^1.35.1", "@solana/web3.js@^1.36.0", "@solana/web3.js@^1.37.1", "@solana/web3.js@^1.42.0", "@solana/web3.js@^1.44.3", "@solana/web3.js@^1.48.0", "@solana/web3.js@^1.56.2", "@solana/web3.js@^1.59.1", "@solana/web3.js@^1.63.0", "@solana/web3.js@^1.63.1", "@solana/web3.js@^1.66.2", "@solana/web3.js@^1.68.0", "@solana/web3.js@^1.73.2":
   version "1.66.2"
   resolved "https://registry.yarnpkg.com/@solana/web3.js/-/web3.js-1.66.2.tgz#80b43c5868b846124fe3ebac7d3943930c3fa60c"
   integrity sha512-RyaHMR2jGmaesnYP045VLeBGfR/gAW3cvZHzMFGg7bkO+WOYOYp1nEllf0/la4U4qsYGKCsO9eEevR5fhHiVHg==


### PR DESCRIPTION
Use the latest version of dual-finance/airdrop. This change changes from ephemeral signers to pda