### PR TITLE
chore: Update spl-gov sdk to 0.3.26 and fix maxVotingTime

### DIFF
--- a/components/AssetsList/BaseGovernanceForm-data.ts
+++ b/components/AssetsList/BaseGovernanceForm-data.ts
@@ -23,7 +23,7 @@ export type BaseGovernanceFormFieldsV3 = {
   /* in days */
   minInstructionHoldUpTime: string
   /* in days */
-  maxVotingTime: string
+  baseVotingTime: string
 
   // 'disabled' for disabled values
   minCommunityTokensToCreateProposal: string | 'disabled'
@@ -53,7 +53,7 @@ export const transformerGovernanceConfig_2_BaseGovernanceFormFieldsV3 = (
   BaseGovernanceFormFieldsV3
 > => ({
   minInstructionHoldUpTime: (x) => getDaysFromTimestamp(x).toString(),
-  maxVotingTime: (x) => getDaysFromTimestamp(x).toString(),
+  baseVotingTime: (x) => getDaysFromTimestamp(x).toString(),
   minCommunityTokensToCreateProposal: (x) =>
     isDisabledVoterWeight(x)
       ? 'disabled'
@@ -85,7 +85,7 @@ export const transformerBaseGovernanceFormFieldsV3_2_GovernanceConfig = (
   Omit<GovernanceConfig & { _programVersion: 3 }, 'reserved'>
 > => ({
   minInstructionHoldUpTime: (x) => getTimestampFromDays(parseFloat(x)),
-  maxVotingTime: (x) => getTimestampFromDays(parseFloat(x)),
+  baseVotingTime: (x) => getTimestampFromDays(parseFloat(x)),
   minCommunityTokensToCreateProposal: (x) =>
     x === 'disabled'
       ? DISABLED_VOTER_WEIGHT

--- a/components/AssetsList/BaseGovernanceFormV3.tsx
+++ b/components/AssetsList/BaseGovernanceFormV3.tsx
@@ -95,14 +95,14 @@ export const BaseGovernanceFormV3 = ({
         />
         <Input
           label="Max voting time (days)"
-          value={form.maxVotingTime}
+          value={form.baseVotingTime}
           name="maxVotingTime"
           type="number"
           min={0.01}
           onChange={(evt) =>
             setForm((prev) => ({
               ...prev,
-              maxVotingTime: evt.target.value !== '' ? evt.target.value : '0',
+              baseVotingTime: evt.target.value !== '' ? evt.target.value : '0',
             }))
           }
           error={formErrors['maxVotingTime']}

--- a/components/AssetsList/NewProgramForm.tsx
+++ b/components/AssetsList/NewProgramForm.tsx
@@ -5,7 +5,11 @@ import PreviousRouteBtn from 'components/PreviousRouteBtn'
 import Tooltip from 'components/Tooltip'
 import useQueryContext from 'hooks/useQueryContext'
 import useRealm from 'hooks/useRealm'
-import { GovernanceConfig, RpcContext, VoteTipping } from '@solana/spl-governance'
+import {
+  GovernanceConfig,
+  RpcContext,
+  VoteTipping,
+} from '@solana/spl-governance'
 import { PublicKey } from '@solana/web3.js'
 import { tryParseKey } from 'tools/validators/pubkey'
 import { isFormValid } from 'utils/formValidation'
@@ -22,11 +26,17 @@ import { registerProgramGovernance } from 'actions/registerProgramGovernance'
 import { GovernanceType } from '@solana/spl-governance'
 import Switch from 'components/Switch'
 import { debounce } from '@utils/debounce'
-import { DISABLED_VOTER_WEIGHT, MIN_COMMUNITY_TOKENS_TO_CREATE_W_0_SUPPLY } from '@tools/constants'
+import {
+  DISABLED_VOTER_WEIGHT,
+  MIN_COMMUNITY_TOKENS_TO_CREATE_W_0_SUPPLY,
+} from '@tools/constants'
 import { getProgramVersionForRealm } from '@models/registry/api'
 import useVotePluginsClientStore from 'stores/useVotePluginsClientStore'
 import { getMintDecimalAmount } from '@tools/sdk/units'
-import { transform, transformerBaseGovernanceFormFieldsV3_2_GovernanceConfig } from './BaseGovernanceForm-data'
+import {
+  transform,
+  transformerBaseGovernanceFormFieldsV3_2_GovernanceConfig,
+} from './BaseGovernanceForm-data'
 interface NewProgramForm extends BaseGovernanceFormFieldsV2 {
   programId: string
   transferAuthority: boolean
@@ -59,7 +69,7 @@ const NewProgramForm = () => {
     mint: realmMint,
     symbol,
     ownVoterWeight,
-    councilMint
+    councilMint,
   } = useRealm()
   const wallet = useWalletStore((s) => s.current)
   const connection = useWalletStore((s) => s.connection)
@@ -132,7 +142,7 @@ const NewProgramForm = () => {
                         : form.minCommunityTokensToCreateProposal,
                     minCouncilTokensToCreateProposal: '1',
                     minInstructionHoldUpTime: form.minInstructionHoldUpTime.toString(),
-                    maxVotingTime: form.maxVotingTime.toString(),
+                    baseVotingTime: form.maxVotingTime.toString(),
                     votingCoolOffTime: '0',
                     depositExemptProposalCount: '10',
                     communityVoteThreshold: form.voteThreshold.toString(),

--- a/components/ProposalActions.tsx
+++ b/components/ProposalActions.tsx
@@ -43,7 +43,7 @@ const ProposalActionsPanel = () => {
     hasVoteTimeExpired && proposal?.account.state === ProposalState.Voting
   const now = new Date().getTime() / 1000 // unix timestamp in seconds
   const mainVotingEndedAt = proposal?.account.signingOffAt
-    ?.addn(governance?.account.config.maxVotingTime || 0)
+    ?.addn(governance?.account.config.baseVotingTime || 0)
     .toNumber()
 
   const votingCoolOffTime = governance?.account.config.votingCoolOffTime || 0

--- a/components/TreasuryAccount/NewTreasuryAccountForm.tsx
+++ b/components/TreasuryAccount/NewTreasuryAccountForm.tsx
@@ -188,7 +188,7 @@ const NewAccountForm = () => {
                         : form.minCommunityTokensToCreateProposal,
                     minCouncilTokensToCreateProposal: '1',
                     minInstructionHoldUpTime: form.minInstructionHoldUpTime.toString(),
-                    maxVotingTime: form.maxVotingTime.toString(),
+                    baseVotingTime: form.maxVotingTime.toString(),
                     votingCoolOffTime: '0',
                     depositExemptProposalCount: '10',
                     communityVoteThreshold: form.voteThreshold.toString(),

--- a/components/VoteCountdown.tsx
+++ b/components/VoteCountdown.tsx
@@ -41,9 +41,9 @@ export function VoteCountdown({
       const now = dayjs().unix()
 
       let timeToVoteEnd = proposal.isPreVotingState()
-        ? governance.config.maxVotingTime
+        ? governance.config.baseVotingTime
         : (proposal.votingAt?.toNumber() ?? 0) +
-          governance.config.maxVotingTime -
+          governance.config.baseVotingTime -
           now
 
       if (timeToVoteEnd <= 0) {

--- a/components/VotePanel/hooks.ts
+++ b/components/VotePanel/hooks.ts
@@ -35,7 +35,7 @@ export const isInCoolOffTime = (
   governance: Governance | undefined
 ) => {
   const mainVotingEndedAt = proposal?.signingOffAt
-    ?.addn(governance?.config.maxVotingTime || 0)
+    ?.addn(governance?.config.baseVotingTime || 0)
     .toNumber()
 
   const votingCoolOffTime = governance?.config.votingCoolOffTime || 0

--- a/components/instructions/programs/governance.tsx
+++ b/components/instructions/programs/governance.tsx
@@ -224,11 +224,11 @@ export const GOVERNANCE_INSTRUCTIONS = {
                 } secs`}
               </p>
               <p>
-                {`maxVotingTime:
+                {`baseVotingTime:
           ${getDaysFromTimestamp(
-            governance.account.config.maxVotingTime
+            governance.account.config.baseVotingTime
           )} days(s) | raw arg: ${
-                  governance.account.config.maxVotingTime
+                  governance.account.config.baseVotingTime
                 } secs`}
               </p>
               <p>
@@ -318,10 +318,10 @@ export const GOVERNANCE_INSTRUCTIONS = {
           )} day(s) | raw arg: ${args.config.minInstructionHoldUpTime} secs`}
               </p>
               <p>
-                {`maxVotingTime:
+                {`baseVotingTime:
           ${getDaysFromTimestamp(
-            args.config.maxVotingTime
-          )} days(s) | raw arg: ${args.config.maxVotingTime} secs`}
+            args.config.baseVotingTime
+          )} days(s) | raw arg: ${args.config.baseVotingTime} secs`}
               </p>
               <p>
                 {`votingCoolOffTime:
@@ -379,9 +379,9 @@ export const GOVERNANCE_INSTRUCTIONS = {
               )} day(s)`}
               </p>
               <p>
-                {`maxVotingTime:
+                {`baseVotingTime:
               ${getDaysFromTimestamp(
-                governance.account.config.maxVotingTime
+                governance.account.config.baseVotingTime
               )} days(s)`}
               </p>
               <p>
@@ -421,8 +421,8 @@ export const GOVERNANCE_INSTRUCTIONS = {
               )} day(s)`}
               </p>
               <p>
-                {`maxVotingTime:
-              ${getDaysFromTimestamp(args.config.maxVotingTime)} days(s)`}
+                {`baseVotingTime:
+              ${getDaysFromTimestamp(args.config.baseVotingTime)} days(s)`}
               </p>
               <p>
                 {`voteTipping:

--- a/components/treasuryV2/Details/WalletDetails/Info/Rules/index.tsx
+++ b/components/treasuryV2/Details/WalletDetails/Info/Rules/index.tsx
@@ -163,7 +163,7 @@ export default function Rules(props: Props) {
                 <Section
                   icon={<CalendarIcon />}
                   name="Unrestricted Voting Time"
-                  value={votingLengthText(governanceConfig.maxVotingTime)}
+                  value={votingLengthText(governanceConfig.baseVotingTime)}
                 />
                 <Section
                   icon={<CalendarIcon />}

--- a/hooks/useHasVoteTimeExpired.ts
+++ b/hooks/useHasVoteTimeExpired.ts
@@ -12,7 +12,7 @@ export const useHasVoteTimeExpired = (
         ? 0 // If vote is finalized then set the timestamp to 0 to make it expired
         : proposal.account.votingAt && governance
         ? proposal.account.votingAt.toNumber() +
-          governance.account.config.maxVotingTime
+          governance.account.config.baseVotingTime
         : undefined
       : undefined
   )

--- a/hooks/useTreasuryInfo/getRulesFromAccount.ts
+++ b/hooks/useTreasuryInfo/getRulesFromAccount.ts
@@ -16,7 +16,7 @@ export function getRulesFromAccount(
 
   if (!rules.common) {
     rules.common = {
-      maxVotingTime: govConfig.maxVotingTime,
+      maxVotingTime: govConfig.baseVotingTime,
       minInstructionHoldupTime: govConfig.minInstructionHoldUpTime,
       votingCoolOffSeconds: govConfig.votingCoolOffTime,
     }

--- a/hub/components/EditWalletRules/createTransaction.ts
+++ b/hub/components/EditWalletRules/createTransaction.ts
@@ -71,7 +71,7 @@ export function createTransaction(
           value: undefined,
         },
     minInstructionHoldUpTime: daysToSeconds(rules.minInstructionHoldupDays),
-    maxVotingTime:
+    baseVotingTime:
       daysToSeconds(rules.maxVoteDays) - hoursToSeconds(rules.coolOffHours),
     communityVoteTipping: convertVoteTipping(communityRules.voteTipping),
     councilVoteThreshold: councilRules?.canVote

--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
     "@solana-mobile/wallet-adapter-mobile": "2.0.0",
     "@solana/buffer-layout": "4.0.0",
     "@solana/governance-program-library": "npm:@civic/governance-program-library@0.16.9-beta.2",
-    "@solana/spl-governance": "0.3.25",
+    "@solana/spl-governance": "0.3.26",
     "@solana/spl-token": "0.1.8",
     "@solana/spl-token-registry": "0.2.4574",
     "@solana/wallet-adapter-backpack": "0.1.13",

--- a/pages/dao/[symbol]/params/components/ParamsView.tsx
+++ b/pages/dao/[symbol]/params/components/ParamsView.tsx
@@ -42,7 +42,7 @@ const ParamsView = ({ activeGovernance }) => {
             label="Max Voting Time"
             padding
             val={getFormattedStringFromDays(
-              activeGovernance.account.config.maxVotingTime / SECS_PER_DAY
+              activeGovernance.account.config.baseVotingTime / SECS_PER_DAY
             )}
           />
           {communityMint && (

--- a/pages/dao/[symbol]/proposal/components/MyProposalsBtn.tsx
+++ b/pages/dao/[symbol]/proposal/components/MyProposalsBtn.tsx
@@ -92,7 +92,7 @@ const MyProposalsBn = () => {
         ? 0 // If vote is finalized then set the timestamp to 0 to make it expired
         : x.account.votingAt && governance
         ? x.account.votingAt.toNumber() +
-          governance.account.config.maxVotingTime
+          governance.account.config.baseVotingTime
         : undefined
       : undefined
     return (

--- a/scripts/governance-notifier.ts
+++ b/scripts/governance-notifier.ts
@@ -133,7 +133,7 @@ async function runNotifier() {
 
       const remainingInSeconds =
         governancesMap[proposal.account.governance.toBase58()].account.config
-          .maxVotingTime +
+          .baseVotingTime +
         proposal.account.votingAt.toNumber() -
         nowInSeconds
       if (

--- a/tools/governance/prepareRealmCreation.ts
+++ b/tools/governance/prepareRealmCreation.ts
@@ -321,10 +321,9 @@ export async function prepareRealmCreation({
     minCommunityTokensToCreateProposal: minCommunityTokensToCreateAsMintValue,
     // Do not use instruction hold up time
     minInstructionHoldUpTime: 0,
-    // baseVotingTime is incorrectly called maxVotingTime in the sdk
     // maxVotingTime = baseVotingTime + votingCoolOffTime
     // since this is actually baseVotingTime, we have to manually subtract the cooloff time.
-    maxVotingTime:
+    baseVotingTime:
       getTimestampFromDays(maxVotingTimeInDays) - VOTING_COOLOFF_TIME_DEFAULT,
     communityVoteTipping: VoteTipping.Disabled,
     councilVoteTipping: VoteTipping.Strict,

--- a/utils/GovernanceTools.tsx
+++ b/utils/GovernanceTools.tsx
@@ -71,7 +71,7 @@ export function getGovernanceConfigFromV2Form(
     minInstructionHoldUpTime: getTimestampFromDays(
       values.minInstructionHoldUpTime
     ),
-    maxVotingTime: getTimestampFromDays(values.maxVotingTime),
+    baseVotingTime: getTimestampFromDays(values.maxVotingTime),
     // Use 1 as default for council tokens.
     // Council tokens are rare and possession of any amount of council tokens should be sufficient to be allowed to create proposals
     // If it turns to be a wrong assumption then it should be exposed in the UI

--- a/yarn.lock
+++ b/yarn.lock
@@ -4490,10 +4490,10 @@
     bs58 "^4.0.1"
     superstruct "^0.15.2"
 
-"@solana/spl-governance@0.3.25":
-  version "0.3.25"
-  resolved "https://registry.yarnpkg.com/@solana/spl-governance/-/spl-governance-0.3.25.tgz#57563003ebd4cf0bf778876035828196e34e29fd"
-  integrity sha512-+qepFswOvG0mHLoLnONw+6bwSuEKr7UhJyeAuM/nodjkR8Z5IfH4HQuOzl+TlPTjMStLFJ7Ja6AzTu+FkPGIUQ==
+"@solana/spl-governance@0.3.26":
+  version "0.3.26"
+  resolved "https://registry.yarnpkg.com/@solana/spl-governance/-/spl-governance-0.3.26.tgz#1a6c56037063654d243cc3ee9503b5b3140bbd6f"
+  integrity sha512-L84AWKcAmEMIWhh5gcfasfDesOMT+IU4i+s0ELgKCN0O9MC/hVrSjTkn68vBhDfCElnJyJTFMAN7NqSbrweD9A==
   dependencies:
     "@solana/web3.js" "^1.22.0"
     axios "^1.1.3"
@@ -4527,14 +4527,14 @@
     bs58 "^4.0.1"
     superstruct "^0.15.2"
 
-"@solana/spl-token-registry@0.2.3775":
+"@solana/spl-token-registry@0.2.3775", "@solana/spl-token-registry@^0.2.1107":
   version "0.2.3775"
   resolved "https://registry.yarnpkg.com/@solana/spl-token-registry/-/spl-token-registry-0.2.3775.tgz#96abffc351fe156917aedb8bba7db94600abed6e"
   integrity sha512-3a6wn6LZ1ZdCt50p9Bz2s8tIh1cJvJue4vvlPlzZ1n2j/0H2Coy4Xx92nIsYot399TjtO9NeLU2NowBDH4vtpg==
   dependencies:
     cross-fetch "3.0.6"
 
-"@solana/spl-token-registry@0.2.4574", "@solana/spl-token-registry@^0.2.1107":
+"@solana/spl-token-registry@0.2.4574":
   version "0.2.4574"
   resolved "https://registry.yarnpkg.com/@solana/spl-token-registry/-/spl-token-registry-0.2.4574.tgz#13f4636b7bec90d2bb43bbbb83512cd90d2ce257"
   integrity sha512-JzlfZmke8Rxug20VT/VpI2XsXlsqMlcORIUivF+Yucj7tFi7A0dXG7h+2UnD0WaZJw8BrUz2ABNkUnv89vbv1A==
@@ -5057,7 +5057,7 @@
     "@wallet-standard/app" "^1.0.1"
     "@wallet-standard/base" "^1.0.1"
 
-"@solana/web3.js@1.42.0", "@solana/web3.js@1.56.0", "@solana/web3.js@1.73.3", "@solana/web3.js@^1.16.1", "@solana/web3.js@^1.17.0", "@solana/web3.js@^1.20.0", "@solana/web3.js@^1.21.0", "@solana/web3.js@^1.22.0", "@solana/web3.js@^1.24.1", "@solana/web3.js@^1.29.2", "@solana/web3.js@^1.30.2", "@solana/web3.js@^1.31.0", "@solana/web3.js@^1.32.0", "@solana/web3.js@^1.35.1", "@solana/web3.js@^1.36.0", "@solana/web3.js@^1.37.1", "@solana/web3.js@^1.42.0", "@solana/web3.js@^1.44.3", "@solana/web3.js@^1.48.0", "@solana/web3.js@^1.56.2", "@solana/web3.js@^1.59.1", "@solana/web3.js@^1.63.0", "@solana/web3.js@^1.63.1", "@solana/web3.js@^1.66.2", "@solana/web3.js@^1.68.0", "@solana/web3.js@^1.73.2":
+"@solana/web3.js@1.42.0", "@solana/web3.js@1.56.0", "@solana/web3.js@1.73.3", "@solana/web3.js@^1.16.1", "@solana/web3.js@^1.17.0", "@solana/web3.js@^1.20.0", "@solana/web3.js@^1.21.0", "@solana/web3.js@^1.22.0", "@solana/web3.js@^1.24.1", "@solana/web3.js@^1.29.2", "@solana/web3.js@^1.30.2", "@solana/web3.js@^1.31.0", "@solana/web3.js@^1.32.0", "@solana/web3.js@^1.35.1", "@solana/web3.js@^1.36.0", "@solana/web3.js@^1.37.1", "@solana/web3.js@^1.42.0", "@solana/web3.js@^1.43.4", "@solana/web3.js@^1.44.3", "@solana/web3.js@^1.48.0", "@solana/web3.js@^1.56.2", "@solana/web3.js@^1.59.1", "@solana/web3.js@^1.63.0", "@solana/web3.js@^1.63.1", "@solana/web3.js@^1.66.2", "@solana/web3.js@^1.68.0", "@solana/web3.js@^1.73.2":
   version "1.73.3"
   resolved "https://registry.yarnpkg.com/@solana/web3.js/-/web3.js-1.73.3.tgz#60e6bd68f6f364d4be360b1e0a03a0a68468a029"
   integrity sha512-vHRMo589XEIpoujpE2sZZ1aMZvfA1ImKfNxobzEFyMb+H5j6mRRUXfdgWD0qJ0sm11e5BcBC7HPeRXJB+7f3Lg==


### PR DESCRIPTION
#### Upgrade spl-gov sdk to 0.3.26 

In `0.3.26` `maxVotingTime` was renamed to `baseVotingTime` to match the corresponding change in `spl-gov V3`

Note: This change only updates the package and fixes compilation errors and doesn't attempt to fix how `baseVotingTime` is used through the codebase.