### PR TITLE
refactor away `connected` from `useWalletStore`

### DIFF
--- a/HeliumVotePlugin/components/LockCommunityTokensBtn.tsx
+++ b/HeliumVotePlugin/components/LockCommunityTokensBtn.tsx
@@ -3,14 +3,15 @@ import { BN } from '@coral-xyz/anchor'
 import { LockClosedIcon } from '@heroicons/react/solid'
 import useRealm from '@hooks/useRealm'
 import { SecondaryButton } from '@components/Button'
-import useWalletStore from 'stores/useWalletStore'
+import useWalletOnePointOh from '@hooks/useWalletOnePointOh'
 
 export const LockCommunityTokensBtn: React.FC<{
   className?: string
   onClick: () => void
 }> = ({ onClick, className = '' }) => {
   const { realmTokenAccount } = useRealm()
-  const connected = useWalletStore((s) => s.connected)
+  const wallet = useWalletOnePointOh()
+  const connected = !!wallet?.connected
 
   const hasTokensInWallet =
     realmTokenAccount && realmTokenAccount.account.amount.gt(new BN(0))

--- a/HeliumVotePlugin/components/LockTokensAccount.tsx
+++ b/HeliumVotePlugin/components/LockTokensAccount.tsx
@@ -68,9 +68,9 @@ export const LockTokensAccount: React.FC<{
   const { error, createPosition } = useCreatePosition()
   const [isOwnerOfPositions, setIsOwnerOfPositions] = useState(true)
   const [isLockModalOpen, setIsLockModalOpen] = useState(false)
-  const connected = useWalletStore((s) => s.connected)
   const connection = useWalletStore((s) => s.connection)
   const wallet = useWalletOnePointOh()
+  const connected = !!wallet?.connected
   const { fetchRealm, fetchWalletTokenAccounts } = useWalletStore(
     (s) => s.actions
   )

--- a/HeliumVotePlugin/components/VotingPowerCard.tsx
+++ b/HeliumVotePlugin/components/VotingPowerCard.tsx
@@ -10,7 +10,6 @@ import { ChevronRightIcon } from '@heroicons/react/solid'
 import InlineNotification from '@components/InlineNotification'
 import DelegateTokenBalanceCard from '@components/TokenBalance/DelegateTokenBalanceCard'
 import { TokenDeposit } from '@components/TokenBalance/TokenBalanceCard'
-import useWalletStore from 'stores/useWalletStore'
 import useHeliumVsrStore from 'HeliumVotePlugin/hooks/useHeliumVsrStore'
 import { MintInfo } from '@solana/spl-token'
 import { VotingPowerBox } from './VotingPowerBox'
@@ -23,8 +22,9 @@ export const VotingPowerCard: React.FC<{
   const { fmtUrlWithCluster } = useQueryContext()
   const [hasGovPower, setHasGovPower] = useState(false)
   const { councilMint, ownTokenRecord, mint, symbol } = useRealm()
-  const connected = useWalletStore((s) => s.connected)
   const wallet = useWalletOnePointOh()
+  const connected = !!wallet?.connected
+
   const councilDepositVisible = !!councilMint
   const { data: tokenOwnerRecordPk } = useAddressQuery_CommunityTokenOwner()
 
@@ -107,7 +107,8 @@ const TokenDepositLock = ({
   isSameWallet: boolean
 }) => {
   const { realm, realmTokenAccount } = useRealm()
-  const connected = useWalletStore((s) => s.connected)
+  const wallet = useWalletOnePointOh()
+  const connected = !!wallet?.connected
   const [amountLocked, votingPower] = useHeliumVsrStore((s) => [
     s.state.amountLocked,
     s.state.votingPower,

--- a/VoteStakeRegistry/components/Account/Account.tsx
+++ b/VoteStakeRegistry/components/Account/Account.tsx
@@ -1,10 +1,10 @@
 import PreviousRouteBtn from '@components/PreviousRouteBtn'
 import { LinkIcon } from '@heroicons/react/outline'
 import MyProposalsBtn from 'pages/dao/[symbol]/proposal/components/MyProposalsBtn'
-import useWalletStore from 'stores/useWalletStore'
 import DelegateCard from '@components/DelegateCard'
 import TokenBalanceCardWrapper from '@components/TokenBalance/TokenBalanceCardWrapper'
 import useRealm from '@hooks/useRealm'
+import useWalletOnePointOh from '@hooks/useWalletOnePointOh'
 
 const AccountInner = ({
   displayPanel,
@@ -13,7 +13,8 @@ const AccountInner = ({
   displayPanel?: boolean
   withHeader?: boolean
 }) => {
-  const connected = useWalletStore((s) => s.connected)
+  const wallet = useWalletOnePointOh()
+  const connected = !!wallet?.connected
   const { realmInfo } = useRealm()
   return (
     <div className="bg-bkg-2 col-span-12 p-4 md:p-6 rounded-lg">

--- a/VoteStakeRegistry/components/Account/LockTokensAccount.tsx
+++ b/VoteStakeRegistry/components/Account/LockTokensAccount.tsx
@@ -73,7 +73,7 @@ const LockTokensAccount: React.FC<{
   const [isLoading, setIsLoading] = useState(false)
   const connection = useWalletStore((s) => s.connection.current)
   const wallet = useWalletOnePointOh()
-  const connected = useWalletStore((s) => s.connected)
+  const connected = !!wallet?.connected
   const mainBoxesClasses = 'bg-bkg-1 col-span-1 p-4 rounded-md'
   const isNextSameRecord = (x, next) => {
     const nextType = Object.keys(next.lockup.kind)[0]

--- a/VoteStakeRegistry/components/Account/LockTokensAccountWithdraw.tsx
+++ b/VoteStakeRegistry/components/Account/LockTokensAccountWithdraw.tsx
@@ -68,7 +68,7 @@ const LockTokensAccount = ({ tokenOwnerRecordPk }) => {
   const connection = useWalletStore((s) => s.connection.current)
   const connnectionContext = useWalletStore((s) => s.connection)
   const wallet = useWalletOnePointOh()
-  const connected = useWalletStore((s) => s.connected)
+  const connected = !!wallet?.connected
   const mainBoxesClasses = 'bg-bkg-1 col-span-1 p-4 rounded-md'
   const isNextSameRecord = (x, next) => {
     const nextType = Object.keys(next.lockup.kind)[0]

--- a/VoteStakeRegistry/components/TokenBalance/DepositCommunityTokensBtn.tsx
+++ b/VoteStakeRegistry/components/TokenBalance/DepositCommunityTokensBtn.tsx
@@ -19,7 +19,7 @@ const DepositCommunityTokensBtn = ({ className = '', inAccountDetails }) => {
   const client = useVotePluginsClientStore((s) => s.state.vsrClient)
   const [isLoading, setIsLoading] = useState(false)
   const wallet = useWalletOnePointOh()
-  const connected = useWalletStore((s) => s.connected)
+  const connected = !!wallet?.connected
   const connection = useWalletStore((s) => s.connection.current)
   const endpoint = useWalletStore((s) => s.connection.endpoint)
   const { fetchRealm, fetchWalletTokenAccounts } = useWalletStore(

--- a/VoteStakeRegistry/components/TokenBalance/LockPluginTokenBalanceCard.tsx
+++ b/VoteStakeRegistry/components/TokenBalance/LockPluginTokenBalanceCard.tsx
@@ -3,7 +3,6 @@ import { PublicKey } from '@solana/web3.js'
 import BN from 'bn.js'
 import useRealm from '@hooks/useRealm'
 import { getTokenOwnerRecordAddress, Proposal } from '@solana/spl-governance'
-import useWalletStore from '../../../stores/useWalletStore'
 import { Option } from '@tools/core/option'
 import { GoverningTokenRole } from '@solana/spl-governance'
 import { fmtMintAmount } from '@tools/sdk/units'
@@ -32,8 +31,8 @@ const LockPluginTokenBalanceCard = ({
   const { fmtUrlWithCluster } = useQueryContext()
   const { councilMint, mint, realm, symbol, config } = useRealm()
   const [tokenOwnerRecordPk, setTokenOwneRecordPk] = useState('')
-  const connected = useWalletStore((s) => s.connected)
   const wallet = useWalletOnePointOh()
+  const connected = !!wallet?.connected
   const isDepositVisible = (
     depositMint: MintInfo | undefined,
     realmMint: PublicKey | undefined
@@ -154,7 +153,8 @@ const TokenDepositLock = ({
   setHasGovPower: (hasGovPower: boolean) => void
 }) => {
   const { realm, realmTokenAccount, councilTokenAccount } = useRealm()
-  const connected = useWalletStore((s) => s.connected)
+  const wallet = useWalletOnePointOh()
+  const connected = !!wallet?.connected
   const deposits = useDepositStore((s) => s.state.deposits)
   const votingPower = useDepositStore((s) => s.state.votingPower)
   const votingPowerFromDeposits = useDepositStore(

--- a/VoteStakeRegistry/components/TokenBalance/WithdrawCommunityTokensBtn.tsx
+++ b/VoteStakeRegistry/components/TokenBalance/WithdrawCommunityTokensBtn.tsx
@@ -37,7 +37,7 @@ const WithDrawCommunityTokens = () => {
   } = useRealm()
   const [isLoading, setIsLoading] = useState(false)
   const wallet = useWalletOnePointOh()
-  const connected = useWalletStore((s) => s.connected)
+  const connected = !!wallet?.connected
   const connection = useWalletStore((s) => s.connection.current)
   const deposits = useDepositStore((s) => s.state.deposits)
   const { fetchRealm, fetchWalletTokenAccounts } = useWalletStore(

--- a/components/AssetsList/AssetsCompactWrapper.tsx
+++ b/components/AssetsList/AssetsCompactWrapper.tsx
@@ -3,7 +3,6 @@ import AssetsList from './AssetsList'
 import { ChevronRightIcon } from '@heroicons/react/solid'
 import useRealm from '@hooks/useRealm'
 import useQueryContext from '@hooks/useQueryContext'
-import useWalletStore from 'stores/useWalletStore'
 import Link from 'next/link'
 import { useRouter } from 'next/router'
 import { TerminalIcon } from '@heroicons/react/outline'
@@ -14,6 +13,7 @@ import {
   NEW_PROGRAM_VIEW,
   renderAddNewAssetTooltip,
 } from 'pages/dao/[symbol]/assets'
+import useWalletOnePointOh from '@hooks/useWalletOnePointOh'
 
 const AssetsCompactWrapper = () => {
   const router = useRouter()
@@ -25,7 +25,8 @@ const AssetsCompactWrapper = () => {
     toManyCommunityOutstandingProposalsForUser,
     toManyCouncilOutstandingProposalsForUse,
   } = useRealm()
-  const connected = useWalletStore((s) => s.connected)
+  const wallet = useWalletOnePointOh()
+  const connected = !!wallet?.connected
   const canCreateGovernance = realm
     ? ownVoterWeight.canCreateGovernance(realm)
     : null

--- a/components/AssetsList/NewProgramForm.tsx
+++ b/components/AssetsList/NewProgramForm.tsx
@@ -74,7 +74,7 @@ const NewProgramForm = () => {
   } = useRealm()
   const wallet = useWalletOnePointOh()
   const connection = useWalletStore((s) => s.connection)
-  const connected = useWalletStore((s) => s.connected)
+  const connected = !!wallet?.connected
   const { fetchRealm } = useWalletStore((s) => s.actions)
   const [form, setForm] = useState<NewProgramForm>({
     ...defaultFormValues,

--- a/components/ConnectWalletButton.tsx
+++ b/components/ConnectWalletButton.tsx
@@ -44,14 +44,12 @@ const ConnectWalletButton = (props) => {
   )
   const { wallets } = useWallet()
 
-  const {
-    connected,
-    providerName,
-    connection,
-    set: setWalletStore,
-  } = useWalletStore((s) => s)
+  const { providerName, connection, set: setWalletStore } = useWalletStore(
+    (s) => s
+  )
 
   const current = useWalletOnePointOh()
+  const connected = !!current?.connected
 
   const provider = useMemo(
     () => getWalletProviderByName(providerName, wallets),

--- a/components/Gateway/GatewayCard.tsx
+++ b/components/Gateway/GatewayCard.tsx
@@ -22,8 +22,8 @@ import useWalletOnePointOh from '@hooks/useWalletOnePointOh'
 // TODO lots of overlap with NftBalanceCard here - we need to separate the logic for creating the Token Owner Record
 // from the rest of this logic
 const GatewayCard = () => {
-  const connected = useWalletStore((s) => s.connected)
   const wallet = useWalletOnePointOh()
+  const connected = !!wallet?.connected
   const client = useVotePluginsClientStore(
     (s) => s.state.currentRealmVotingClient
   )

--- a/components/NewRealmWizard/PageTemplate.tsx
+++ b/components/NewRealmWizard/PageTemplate.tsx
@@ -5,7 +5,6 @@ import Head from 'next/head'
 import { isWizardValid, validateSolAddress } from '@utils/formValidation'
 
 import CreateDAOWizard from '@components/NewRealmWizard/CreateDAOWizard'
-import useWalletStore from 'stores/useWalletStore'
 
 // import { FORM_NAME as NFT_FORM } from 'pages/realms/new/nft'
 import { FORM_NAME as MULTISIG_WALLET_FORM } from 'pages/realms/new/multisig'
@@ -30,8 +29,8 @@ export default function FormPage({
   handleSubmit,
   submissionPending,
 }) {
-  const connected = useWalletStore((s) => s.connected)
   const wallet = useWalletOnePointOh()
+  const connected = !!wallet?.connected
   const userAddress = wallet?.publicKey?.toBase58()
 
   const { query, push } = useRouter()

--- a/components/NewRealmWizard/components/TokenInput.tsx
+++ b/components/NewRealmWizard/components/TokenInput.tsx
@@ -59,9 +59,9 @@ export default function TokenInput({
   onValidation,
   disableMinTokenInput = false,
 }) {
-  const connected = useWalletStore((s) => s.connected)
   const connection = useWalletStore((s) => s.connection)
   const wallet = useWalletOnePointOh()
+  const connected = !!wallet?.connected
   const [tokenList, setTokenList] = useState<TokenInfo[] | undefined>()
   const [tokenMintAddress, setTokenMintAddress] = useState('')
   const [tokenInfo, setTokenInfo] = useState<TokenWithMintInfo | undefined>()

--- a/components/NewRealmWizard/components/steps/AddNFTCollectionForm.tsx
+++ b/components/NewRealmWizard/components/steps/AddNFTCollectionForm.tsx
@@ -239,9 +239,9 @@ export default function AddNFTCollectionForm({
   onSubmit,
   onPrevClick,
 }) {
-  const connected = useWalletStore((s) => s.connected)
   const connection = useWalletStore((s) => s.connection)
   const wallet = useWalletOnePointOh()
+  const connected = !!wallet?.connected
   const [walletConnecting, setWalletConnecting] = useState(false)
   const [requestPending, setRequestPending] = useState(false)
   const [isModalOpen, setIsModalOpen] = useState(false)

--- a/components/NotificationsCard/NotificationCardContainer.tsx
+++ b/components/NotificationsCard/NotificationCardContainer.tsx
@@ -10,7 +10,6 @@ import {
 import { firstOrNull } from '@utils/helpers'
 import { useRouter } from 'next/router'
 import { useCallback, useEffect, useState } from 'react'
-import useWalletStore from 'stores/useWalletStore'
 
 type Props = {
   onClose: () => void
@@ -28,7 +27,7 @@ const NotificationCardContainer: React.FC<Props> = ({
 
   const endpoint = cluster ? (cluster as EndpointTypes) : 'mainnet'
   const wallet = useWalletOnePointOh()
-  const connected = useWalletStore((s) => s.connected)
+  const connected = !!wallet?.connected
   let env = BlockchainEnvironment.MainNetBeta
 
   switch (endpoint) {

--- a/components/NotificationsCard/index.tsx
+++ b/components/NotificationsCard/index.tsx
@@ -21,7 +21,6 @@ import React, {
 } from 'react'
 import { useCallback } from 'react'
 
-import useWalletStore from '../../stores/useWalletStore'
 import Button from '../Button'
 import Input from '../inputs/Input'
 import NotifiFullLogo from './NotifiFullLogo'
@@ -72,7 +71,7 @@ const NotificationsCard = ({
   const [firstTimeUser, setFirstTimeUser] = useState<boolean>(false)
 
   const wallet = useWalletOnePointOh()
-  const connected = useWalletStore((s) => s.connected)
+  const connected = !!wallet?.connected
 
   const alerts = data?.alerts
   const sources = data?.sources

--- a/components/ProposalActions.tsx
+++ b/components/ProposalActions.tsx
@@ -29,7 +29,7 @@ const ProposalActionsPanel = () => {
   )
   const { realmInfo } = useRealm()
   const wallet = useWalletOnePointOh()
-  const connected = useWalletStore((s) => s.connected)
+  const connected = !!wallet?.connected
   const hasVoteTimeExpired = useHasVoteTimeExpired(governance, proposal!)
   const signatories = useWalletStore((s) => s.selectedProposal.signatories)
   const connection = useWalletStore((s) => s.connection)

--- a/components/ProposalVotingPower/LockedCommunityNFTRecordVotingPower.tsx
+++ b/components/ProposalVotingPower/LockedCommunityNFTRecordVotingPower.tsx
@@ -3,7 +3,6 @@ import classNames from 'classnames'
 import { BigNumber } from 'bignumber.js'
 import useRealm from '@hooks/useRealm'
 import useProposal from '@hooks/useProposal'
-import useWalletStore from 'stores/useWalletStore'
 import useHeliumVsrStore from 'HeliumVotePlugin/hooks/useHeliumVsrStore'
 import { fmtMintAmount, getMintDecimalAmount } from '@tools/sdk/units'
 import { getMintMetadata } from '@components/instructions/programs/splToken'
@@ -28,8 +27,8 @@ export default function LockedCommunityNFTRecordVotingPower(props: Props) {
   const [amount, setAmount] = useState(new BigNumber(0))
   const { mint, realm, ownTokenRecord, realmTokenAccount, symbol } = useRealm()
   const { proposal } = useProposal()
-  const connected = useWalletStore((s) => s.connected)
   const wallet = useWalletOnePointOh()
+  const connected = !!wallet?.connected
   const { data: tokenOwnerRecordPk } = useAddressQuery_CommunityTokenOwner()
   const [currentClient] = useVotePluginsClientStore((s) => [
     s.state.currentRealmVotingClient,

--- a/components/ProposalVotingPower/NftVotingPower.tsx
+++ b/components/ProposalVotingPower/NftVotingPower.tsx
@@ -30,8 +30,8 @@ export default function NftVotingPower(props: Props) {
   const votingPower = useNftPluginStore((s) => s.state.votingPower)
   const maxWeight = useNftPluginStore((s) => s.state.maxVoteRecord)
   const isLoading = useNftPluginStore((s) => s.state.isLoadingNfts)
-  const connected = useWalletStore((s) => s.connected)
   const wallet = useWalletOnePointOh()
+  const connected = !!wallet?.connected
   const connection = useWalletStore((s) => s.connection)
   const fetchRealm = useWalletStore((s) => s.actions.fetchRealm)
   const { ownTokenRecord, realm, realmInfo } = useRealm()

--- a/components/ProposalVotingPower/VotingPower.tsx
+++ b/components/ProposalVotingPower/VotingPower.tsx
@@ -26,6 +26,7 @@ import LockedCommunityVotingPower from './LockedCommunityVotingPower'
 import LockedCouncilVotingPower from './LockedCouncilVotingPower'
 import NftVotingPower from './NftVotingPower'
 import LockedCommunityNFTRecordVotingPower from './LockedCommunityNFTRecordVotingPower'
+import useWalletOnePointOh from '@hooks/useWalletOnePointOh'
 
 enum Type {
   Council,
@@ -120,7 +121,8 @@ export default function VotingPower(props: Props) {
     ownTokenRecord,
     realm,
   } = useRealm()
-  const connected = useWalletStore((s) => s.connected)
+  const wallet = useWalletOnePointOh()
+  const connected = !!wallet?.connected
   const tokenRole = useWalletStore((s) => s.selectedProposal.tokenRole)
 
   const types = getTypes(

--- a/components/TokenBalance/NftBalanceCard.tsx
+++ b/components/TokenBalance/NftBalanceCard.tsx
@@ -28,8 +28,8 @@ interface Props {
 
 const NftBalanceCard = ({ inAccountDetails, showView }: Props) => {
   const { fmtUrlWithCluster } = useQueryContext()
-  const connected = useWalletStore((s) => s.connected)
   const wallet = useWalletOnePointOh()
+  const connected = !!wallet?.connected
   const client = useVotePluginsClientStore(
     (s) => s.state.currentRealmVotingClient
   )

--- a/components/TokenBalance/SwitchboardPermissionCard.tsx
+++ b/components/TokenBalance/SwitchboardPermissionCard.tsx
@@ -14,8 +14,8 @@ import { sbRefreshWeight } from '../../actions/switchboardRefreshVoterWeight'
 
 const SwitchboardPermissionCard = () => {
   const { fmtUrlWithCluster } = useQueryContext()
-  const connected = useWalletStore((s) => s.connected)
   const wallet = useWalletOnePointOh()
+  const connected = !!wallet?.connected
 
   const switchboardVoterWeight = useSwitchboardPluginStore(
     (s) => s.state.votingPower

--- a/components/TokenBalance/TokenBalanceCard.tsx
+++ b/components/TokenBalance/TokenBalanceCard.tsx
@@ -54,7 +54,8 @@ const TokenBalanceCard = ({
   const realmProgramId = useWalletStore((s) => s.selectedRealm.programId)
   const [hasGovPower, setHasGovPower] = useState<boolean>(false)
   const { councilMint, mint, realm } = useRealm()
-  const connected = useWalletStore((s) => s.connected)
+  const wallet = useWalletOnePointOh()
+  const connected = !!wallet?.connected
   const isDepositVisible = (
     depositMint: MintInfo | undefined,
     realmMint: PublicKey | undefined
@@ -143,7 +144,7 @@ export const TokenDeposit = ({
   setHasGovPower?: (hasGovPower: boolean) => void
 }) => {
   const wallet = useWalletOnePointOh()
-  const connected = useWalletStore((s) => s.connected)
+  const connected = !!wallet?.connected
   const connection = useWalletStore((s) => s.connection.current)
   const { fetchWalletTokenAccounts, fetchRealm } = useWalletStore(
     (s) => s.actions

--- a/components/TokenBalance/TokenBalanceCardWrapper.tsx
+++ b/components/TokenBalance/TokenBalanceCardWrapper.tsx
@@ -12,8 +12,8 @@ import {
 import GatewayCard from '@components/Gateway/GatewayCard'
 import ClaimUnreleasedNFTs from './ClaimUnreleasedNFTs'
 import Link from 'next/link'
-import useWalletStore from 'stores/useWalletStore'
 import { useAddressQuery_CommunityTokenOwner } from '@hooks/queries/addresses/tokenOwner'
+import useWalletOnePointOh from '@hooks/useWalletOnePointOh'
 
 const LockPluginTokenBalanceCard = dynamic(
   () =>
@@ -41,7 +41,8 @@ const SwitchboardPermissionCard = dynamic(
 const GovernancePowerTitle = () => {
   const { symbol } = useRealm()
   const { fmtUrlWithCluster } = useQueryContext()
-  const connected = useWalletStore((s) => s.connected)
+  const wallet = useWalletOnePointOh()
+  const connected = !!wallet?.connected
   const { data: tokenOwnerRecordPk } = useAddressQuery_CommunityTokenOwner()
 
   return (

--- a/components/TreasuryAccount/AccountOverview.tsx
+++ b/components/TreasuryAccount/AccountOverview.tsx
@@ -39,6 +39,7 @@ import {
 import tokenPriceService from '@utils/services/tokenPrice'
 import { EVERLEND } from '../../Strategies/protocols/everlend/tools'
 import { findAssociatedTokenAccount } from '@everlend/common'
+import useWalletOnePointOh from '@hooks/useWalletOnePointOh'
 
 type InvestmentType = TreasuryStrategy & {
   investedAmount: number
@@ -65,7 +66,8 @@ const AccountOverview = () => {
   const isSplToken = currentAccount?.type === AccountType.TOKEN
   const isAuxiliaryAccount = currentAccount?.type === AccountType.AuxiliaryToken
   const { canUseTransferInstruction } = useGovernanceAssets()
-  const connected = useWalletStore((s) => s.connected)
+  const wallet = useWalletOnePointOh()
+  const connected = !!wallet?.connected
   const connection = useWalletStore((s) => s.connection)
   const recentActivity = useTreasuryAccountStore((s) => s.recentActivity)
   const isLoadingRecentActivity = useTreasuryAccountStore(

--- a/components/TreasuryAccount/DepositNFT.tsx
+++ b/components/TreasuryAccount/DepositNFT.tsx
@@ -7,6 +7,7 @@ import DepositNFTAddress from './DepositNFTAddress'
 import useTreasuryAccountStore from 'stores/useTreasuryAccountStore'
 import { ArrowLeftIcon, ExternalLinkIcon } from '@heroicons/react/solid'
 import { getExplorerUrl } from '@components/explorer/tools'
+import useWalletOnePointOh from '@hooks/useWalletOnePointOh'
 
 enum DepositState {
   DepositNFTFromWallet,
@@ -16,7 +17,8 @@ enum DepositState {
 const DepositNFT = ({ onClose }) => {
   const currentAccount = useTreasuryAccountStore((s) => s.currentAccount)
   const connection = useWalletStore((s) => s.connection)
-  const connected = useWalletStore((s) => s.connected)
+  const wallet = useWalletOnePointOh()
+  const connected = !!wallet?.connected
   const [
     currentDepositView,
     setCurrentDepositView,

--- a/components/TreasuryAccount/DepositNFTAddress.tsx
+++ b/components/TreasuryAccount/DepositNFTAddress.tsx
@@ -37,7 +37,7 @@ const DepositNFTAddress = ({ additionalBtns }: { additionalBtns?: any }) => {
 
   const wallet = useWalletOnePointOh()
   const { realm } = useRealm()
-  const connected = useWalletStore((s) => s.connected)
+  const connected = !!wallet?.connected
   const [form, setForm] = useState({
     mint: '',
   })

--- a/components/TreasuryAccount/DepositNFTFromWallet.tsx
+++ b/components/TreasuryAccount/DepositNFTFromWallet.tsx
@@ -27,7 +27,7 @@ const DepositNFTFromWallet = ({ additionalBtns }: { additionalBtns?: any }) => {
   const { getNfts } = useTreasuryAccountStore()
   const [selectedNfts, setSelectedNfts] = useState<NFTWithMint[]>([])
   const wallet = useWalletOnePointOh()
-  const connected = useWalletStore((s) => s.connected)
+  const connected = !!wallet?.connected
   const connection = useWalletStore((s) => s.connection)
   const [isLoading, setIsLoading] = useState(false)
   const [sendingSuccess, setSendingSuccess] = useState(false)

--- a/components/TreasuryAccount/NewTreasuryAccountForm.tsx
+++ b/components/TreasuryAccount/NewTreasuryAccountForm.tsx
@@ -110,7 +110,7 @@ const NewAccountForm = () => {
   const filteredTypes = types.filter((x) => !x.hide)
   const wallet = useWalletOnePointOh()
   const connection = useWalletStore((s) => s.connection)
-  const connected = useWalletStore((s) => s.connected)
+  const connected = !!wallet?.connected
   const { fetchRealm } = useWalletStore((s) => s.actions)
   const [form, setForm] = useState<NewTreasuryAccountForm>({
     ...defaultFormValues,

--- a/components/VotePanel/CastVoteButtons.tsx
+++ b/components/VotePanel/CastVoteButtons.tsx
@@ -13,14 +13,15 @@ import {
 import useRealm from '@hooks/useRealm'
 import { VotingClientType } from '@utils/uiTypes/VotePlugin'
 import useVotePluginsClientStore from 'stores/useVotePluginsClientStore'
-import useWalletStore from 'stores/useWalletStore'
+import useWalletOnePointOh from '@hooks/useWalletOnePointOh'
 
 const useCanVote = () => {
   const client = useVotePluginsClientStore(
     (s) => s.state.currentRealmVotingClient
   )
   const { ownVoterWeight } = useRealm()
-  const connected = useWalletStore((s) => s.connected)
+  const wallet = useWalletOnePointOh()
+  const connected = !!wallet?.connected
 
   const { data: ownVoteRecord } = useProposalVoteRecordQuery('electoral')
   const voterTokenRecord = useVoterTokenRecord()

--- a/components/VotePanel/VetoButtons.tsx
+++ b/components/VotePanel/VetoButtons.tsx
@@ -2,6 +2,7 @@ import Button from '@components/Button'
 import VoteCommentModal from '@components/VoteCommentModal'
 import { BanIcon } from '@heroicons/react/solid'
 import useRealm from '@hooks/useRealm'
+import useWalletOnePointOh from '@hooks/useWalletOnePointOh'
 import {
   GoverningTokenRole,
   VoteThresholdType,
@@ -57,7 +58,8 @@ const useCanVeto = ():
   | { canVeto: true }
   | { canVeto: false; message: string } => {
   const { ownVoterWeight } = useRealm()
-  const connected = useWalletStore((s) => s.connected)
+  const wallet = useWalletOnePointOh()
+  const connected = !!wallet?.connected
   const isVetoable = useIsVetoable()
   const { data: userVetoRecord } = useProposalVoteRecordQuery('veto')
   const voterTokenRecord = useUserVetoTokenRecord()

--- a/components/VotePanel/VotePanel.tsx
+++ b/components/VotePanel/VotePanel.tsx
@@ -7,10 +7,12 @@ import VetoButtons from './VetoButtons'
 import { CastVoteButtons } from './CastVoteButtons'
 import { YouVoted } from './YouVoted'
 import { useIsVoting, useProposalVoteRecordQuery } from './hooks'
+import useWalletOnePointOh from '@hooks/useWalletOnePointOh'
 
 const VotePanel = () => {
   const { proposal } = useWalletStore((s) => s.selectedProposal)
-  const connected = useWalletStore((s) => s.connected)
+  const wallet = useWalletOnePointOh()
+  const connected = !!wallet?.connected
 
   const { data: ownVoteRecord } = useProposalVoteRecordQuery('electoral')
 

--- a/components/VotePanel/YouVoted.tsx
+++ b/components/VotePanel/YouVoted.tsx
@@ -38,7 +38,7 @@ export const YouVoted = ({ quorum }: { quorum: 'electoral' | 'veto' }) => {
   const { realm, realmInfo } = useRealm()
   const wallet = useWalletOnePointOh()
   const connection = useWalletStore((s) => s.connection)
-  const connected = useWalletStore((s) => s.connected)
+  const connected = !!wallet?.connected
   const refetchProposals = useWalletStore((s) => s.actions.refetchProposals)
   const fetchProposal = useWalletStore((s) => s.actions.fetchProposal)
   const { governance } = useWalletStore((s) => s.selectedProposal)

--- a/components/chat/DiscussionForm.tsx
+++ b/components/chat/DiscussionForm.tsx
@@ -14,7 +14,6 @@ import useWalletOnePointOh from '@hooks/useWalletOnePointOh'
 
 const DiscussionForm = () => {
   const [comment, setComment] = useState('')
-  const connected = useWalletStore((s) => s.connected)
   const {
     ownVoterWeight,
     realmInfo,
@@ -28,6 +27,7 @@ const DiscussionForm = () => {
   const [submitting, setSubmitting] = useState(false)
 
   const wallet = useWalletOnePointOh()
+  const connected = !!wallet?.connected
   const connection = useWalletStore((s) => s.connection)
   const { proposal } = useWalletStore((s) => s.selectedProposal)
   const { fetchChatMessages } = useWalletStore((s) => s.actions)

--- a/components/explorer/inspectorButton.tsx
+++ b/components/explorer/inspectorButton.tsx
@@ -17,7 +17,7 @@ export default function InspectorButton({
 }) {
   const connection = useWalletStore((s) => s.connection)
   const wallet = useWalletOnePointOh()
-  const connected = useWalletStore((s) => s.connected)
+  const connected = !!wallet?.connected
   const wasExecuted =
     proposalInstruction.account.executionStatus ===
     InstructionExecutionStatus.Success

--- a/components/instructions/ExecuteAllInstructionButton.tsx
+++ b/components/instructions/ExecuteAllInstructionButton.tsx
@@ -101,7 +101,7 @@ export function ExecuteAllInstructionButton({
   const wallet = useWalletOnePointOh()
   const connection = useWalletStore((s) => s.connection)
   const refetchProposals = useWalletStore((s) => s.actions.refetchProposals)
-  const connected = useWalletStore((s) => s.connected)
+  const connected = !!wallet?.connected
 
   const [currentSlot, setCurrentSlot] = useState(0)
 

--- a/components/instructions/ExecuteInstructionButton.tsx
+++ b/components/instructions/ExecuteInstructionButton.tsx
@@ -54,7 +54,7 @@ export function ExecuteInstructionButton({
   const wallet = useWalletOnePointOh()
   const connection = useWalletStore((s) => s.connection)
   const refetchProposals = useWalletStore((s) => s.actions.refetchProposals)
-  const connected = useWalletStore((s) => s.connected)
+  const connected = !!wallet?.connected
 
   const [currentSlot, setCurrentSlot] = useState(0)
 

--- a/components/treasuryV2/Details/DomainsDetails/Info/Domain.tsx
+++ b/components/treasuryV2/Details/DomainsDetails/Info/Domain.tsx
@@ -10,9 +10,9 @@ import Tooltip from '@components/Tooltip'
 
 import useRealm from '@hooks/useRealm'
 import useQueryContext from '@hooks/useQueryContext'
-import useWalletStore from 'stores/useWalletStore'
 
 import { Domain as DomainModel } from '@models/treasury/Domain'
+import useWalletOnePointOh from '@hooks/useWalletOnePointOh'
 
 interface Props {
   domain: DomainModel
@@ -20,7 +20,8 @@ interface Props {
 
 const Domain: React.FC<Props> = (props) => {
   const { fmtUrlWithCluster } = useQueryContext()
-  const connected = useWalletStore((s) => s.connected)
+  const wallet = useWalletOnePointOh()
+  const connected = !!wallet?.connected
   const {
     symbol,
     realm,

--- a/components/treasuryV2/Details/MintDetails/Header.tsx
+++ b/components/treasuryV2/Details/MintDetails/Header.tsx
@@ -15,7 +15,6 @@ import useRealm from '@hooks/useRealm'
 import Modal from '@components/Modal'
 import AddMemberForm from '@components/Members/AddMemberForm'
 import useGovernanceAssets from '@hooks/useGovernanceAssets'
-import useWalletStore from 'stores/useWalletStore'
 import useQueryContext from '@hooks/useQueryContext'
 import { Instructions } from '@utils/uiTypes/proposalCreationTypes'
 import MetadataCreationModal from 'pages/dao/[symbol]/params/MetadataCreationModal'
@@ -27,6 +26,7 @@ import CommunityMintIcon from '../../icons/CommunityMintIcon'
 import TokenIcon from '../../icons/TokenIcon'
 import { GoverningTokenType } from '@solana/spl-governance'
 import useProgramVersion from '@hooks/useProgramVersion'
+import useWalletOnePointOh from '@hooks/useWalletOnePointOh'
 
 interface Props {
   className?: string
@@ -61,7 +61,8 @@ export default function Header(props: Props) {
     toManyCouncilOutstandingProposalsForUse,
     toManyCommunityOutstandingProposalsForUser,
   } = useRealm()
-  const connected = useWalletStore((s) => s.connected)
+  const wallet = useWalletOnePointOh()
+  const connected = !!wallet?.connected
   const router = useRouter()
   const { fmtUrlWithCluster } = useQueryContext()
   const tokenType = useTokenType(props.mint.tokenRole)

--- a/components/treasuryV2/Details/ProgramsDetails/Info/Overview/Program.tsx
+++ b/components/treasuryV2/Details/ProgramsDetails/Info/Overview/Program.tsx
@@ -18,8 +18,8 @@ import Modal from '@components/Modal'
 import Tooltip from '@components/Tooltip'
 import TransferUpgradeAuthority from '@components/AssetsList/TransferUpgradeAuthority'
 import UpgradeProgram from '@components/AssetsList/UpgradeProgram'
-import useWalletStore from 'stores/useWalletStore'
 import useGovernanceAssets from '@hooks/useGovernanceAssets'
+import useWalletOnePointOh from '@hooks/useWalletOnePointOh'
 
 interface Props {
   className?: string
@@ -28,7 +28,8 @@ interface Props {
 
 export default function Program(props: Props) {
   const { canUseProgramUpgradeInstruction } = useGovernanceAssets()
-  const connected = useWalletStore((s) => s.connected)
+  const wallet = useWalletOnePointOh()
+  const connected = !!wallet?.connected
   const [closeBuffersModalOpen, setOpenCloseBuffersModalOpen] = useState(false)
   const [
     transferAuthorityModalOpen,

--- a/components/treasuryV2/Details/TokenDetails/Auction.tsx
+++ b/components/treasuryV2/Details/TokenDetails/Auction.tsx
@@ -1,7 +1,7 @@
 import Button from '@components/Button'
+import useWalletOnePointOh from '@hooks/useWalletOnePointOh'
 import { Token } from '@models/treasury/Asset'
 import { useState } from 'react'
-import useWalletStore from 'stores/useWalletStore'
 import BuyModal from '../Auction/BuyModal'
 import SellModal from '../Auction/SellModal'
 
@@ -11,7 +11,8 @@ interface Props {
 }
 
 export default function Auction(props: Props) {
-  const connected = useWalletStore((s) => s.connected)
+  const wallet = useWalletOnePointOh()
+  const connected = !!wallet?.connected
   const [sellModalOpen, setSellModalOpen] = useState(false)
   const closeSellModal = () => {
     setSellModalOpen(false)

--- a/components/treasuryV2/Details/WalletDetails/AddAssetModal/index.tsx
+++ b/components/treasuryV2/Details/WalletDetails/AddAssetModal/index.tsx
@@ -5,9 +5,9 @@ import { Wallet } from '@models/treasury/Wallet'
 import Button from '@components/Button'
 import Modal from '@components/Modal'
 import useRealm from '@hooks/useRealm'
-import useWalletStore from 'stores/useWalletStore'
 import WalletQRCode from '@components/WalletQRCode'
 import Address from '@components/Address'
+import useWalletOnePointOh from '@hooks/useWalletOnePointOh'
 
 interface TokenAccount {
   iconUrl?: string
@@ -44,7 +44,8 @@ interface Props {
 
 export default function AddAssetModal(props: Props) {
   const { ownVoterWeight, realmInfo, realm } = useRealm()
-  const connected = useWalletStore((s) => s.connected)
+  const wallet = useWalletOnePointOh()
+  const connected = !!wallet?.connected
 
   const tokenOwnerRecord = ownVoterWeight.canCreateGovernanceUsingCouncilTokens()
     ? ownVoterWeight.councilTokenRecord

--- a/components/treasuryV2/WalletList/NewWalletButton.tsx
+++ b/components/treasuryV2/WalletList/NewWalletButton.tsx
@@ -1,16 +1,16 @@
 import { PlusCircleIcon } from '@heroicons/react/outline'
 import { useRouter } from 'next/router'
-
-import useWalletStore from 'stores/useWalletStore'
 import useRealm from '@hooks/useRealm'
 import Tooltip from '@components/Tooltip'
 import { LinkButton } from '@components/Button'
 import useQueryContext from '@hooks/useQueryContext'
+import useWalletOnePointOh from '@hooks/useWalletOnePointOh'
 
 export const NEW_TREASURY_ROUTE = `/treasury/new`
 
 export default function NewWalletButton() {
-  const connected = useWalletStore((s) => s.connected)
+  const wallet = useWalletOnePointOh()
+  const connected = !!wallet?.connected
   const {
     ownVoterWeight,
     realm,

--- a/hooks/useInitWallet.tsx
+++ b/hooks/useInitWallet.tsx
@@ -94,9 +94,6 @@ export default function useInitWallet() {
   useEffect(() => {
     if (!wallet) return
     wallet.on('connect', async () => {
-      setWalletStore((state) => {
-        state.connected = true
-      })
       notify({
         message: 'Wallet connected',
         description:
@@ -111,7 +108,6 @@ export default function useInitWallet() {
     })
     wallet.on('disconnect', () => {
       setWalletStore((state) => {
-        state.connected = false
         state.tokenAccounts = []
       })
       notify({
@@ -121,9 +117,6 @@ export default function useInitWallet() {
     })
     return () => {
       wallet?.disconnect?.()
-      setWalletStore((state) => {
-        state.connected = false
-      })
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps -- TODO please fix, it can cause difficult bugs. You might wanna check out https://bobbyhadz.com/blog/react-hooks-exhaustive-deps for info. -@asktree
   }, [wallet])

--- a/hooks/useProposalCreationButtonTooltip.ts
+++ b/hooks/useProposalCreationButtonTooltip.ts
@@ -1,11 +1,12 @@
 import { Governance, ProgramAccount } from '@solana/spl-governance'
-import useWalletStore from 'stores/useWalletStore'
 import useRealm from './useRealm'
+import useWalletOnePointOh from './useWalletOnePointOh'
 
 const useProposalCreationButtonTooltip = (
   governances?: ProgramAccount<Governance>[]
 ) => {
-  const connected = useWalletStore((s) => s.connected)
+  const wallet = useWalletOnePointOh()
+  const connected = !!wallet?.connected
   const {
     ownVoterWeight,
     toManyCommunityOutstandingProposalsForUser,

--- a/hooks/useRealm.tsx
+++ b/hooks/useRealm.tsx
@@ -41,8 +41,8 @@ export default function useRealm() {
   const router = useRouter()
   const { symbol } = router.query
   const connection = useWalletStore((s) => s.connection)
-  const connected = useWalletStore((s) => s.connected)
   const wallet = useWalletOnePointOh()
+  const connected = !!wallet?.connected
   const tokenAccounts = useWalletStore((s) => s.tokenAccounts)
   const {
     realm,

--- a/hooks/useVotingPlugins.ts
+++ b/hooks/useVotingPlugins.ts
@@ -79,7 +79,7 @@ export function useVotingPlugins() {
   const switchboardStore = useSwitchboardPluginStore()
   const wallet = useWalletOnePointOh()
   const connection = useWalletStore((s) => s.connection)
-  const connected = useWalletStore((s) => s.connected)
+  const connected = !!wallet?.connected
 
   const [
     currentClient,

--- a/hooks/useWalletDeprecated.tsx
+++ b/hooks/useWalletDeprecated.tsx
@@ -2,11 +2,12 @@ import { AnchorProvider, Wallet } from '@coral-xyz/anchor'
 import { useMemo } from 'react'
 
 import useWalletStore from '../stores/useWalletStore'
+import useWalletOnePointOh from './useWalletOnePointOh'
 
 export default function useWalletDeprecated() {
-  const { connected, connection, current: wallet } = useWalletStore(
-    (state) => state
-  )
+  const { connection } = useWalletStore((state) => state)
+  const wallet = useWalletOnePointOh()
+  const connected = !!wallet?.connected
 
   const anchorProvider = useMemo(() => {
     const options = AnchorProvider.defaultOptions()

--- a/pages/dao/[symbol]/assets/index.tsx
+++ b/pages/dao/[symbol]/assets/index.tsx
@@ -4,10 +4,10 @@ import Tooltip from '@components/Tooltip'
 import useRealm from '@hooks/useRealm'
 import useQueryContext from '@hooks/useQueryContext'
 import { useRouter } from 'next/router'
-import useWalletStore from 'stores/useWalletStore'
 import PreviousRouteBtn from '@components/PreviousRouteBtn'
 import { LinkButton } from '@components/Button'
 import { PlusCircleIcon } from '@heroicons/react/outline'
+import useWalletOnePointOh from '@hooks/useWalletOnePointOh'
 export const NEW_PROGRAM_VIEW = `/program/new`
 
 const Assets = () => {
@@ -19,7 +19,8 @@ const Assets = () => {
     toManyCommunityOutstandingProposalsForUser,
     toManyCouncilOutstandingProposalsForUse,
   } = useRealm()
-  const connected = useWalletStore((s) => s.connected)
+  const wallet = useWalletOnePointOh()
+  const connected = !!wallet?.connected
   const { fmtUrlWithCluster } = useQueryContext()
   const goToNewAssetForm = () => {
     router.push(fmtUrlWithCluster(`/dao/${symbol}${NEW_PROGRAM_VIEW}`))

--- a/pages/dao/[symbol]/members/Members.tsx
+++ b/pages/dao/[symbol]/members/Members.tsx
@@ -4,7 +4,6 @@ import MemberOverview from '@components/Members/MemberOverview'
 import { PlusCircleIcon, SearchIcon, UsersIcon } from '@heroicons/react/outline'
 import useGovernanceAssets from '@hooks/useGovernanceAssets'
 import Tooltip from '@components/Tooltip'
-import useWalletStore from 'stores/useWalletStore'
 import Modal from '@components/Modal'
 import { AddCouncilMemberForm } from '@components/Members/AddMemberForm'
 import PreviousRouteBtn from '@components/PreviousRouteBtn'
@@ -15,6 +14,7 @@ import Input from '@components/inputs/Input'
 import { Member } from '@utils/uiTypes/members'
 import useMembersStore from 'stores/useMembersStore'
 import PaginationComponent from '@components/Pagination'
+import useWalletOnePointOh from '@hooks/useWalletOnePointOh'
 
 const Members = () => {
   const {
@@ -25,7 +25,8 @@ const Members = () => {
   const pagination = useRef<{ setPage: (val) => void }>(null)
   const membersPerPage = 10
   const activeMembers = useMembersStore((s) => s.compact.activeMembers)
-  const connected = useWalletStore((s) => s.connected)
+  const wallet = useWalletOnePointOh()
+  const connected = !!wallet?.connected
   const {
     canUseMintInstruction,
     canMintRealmCouncilToken,

--- a/pages/dao/[symbol]/proposal/components/MyProposalsBtn.tsx
+++ b/pages/dao/[symbol]/proposal/components/MyProposalsBtn.tsx
@@ -37,7 +37,7 @@ import useWalletOnePointOh from '@hooks/useWalletOnePointOh'
 const MyProposalsBn = () => {
   const [modalIsOpen, setModalIsOpen] = useState(false)
   const wallet = useWalletOnePointOh()
-  const connected = useWalletStore((s) => s.connected)
+  const connected = !!wallet?.connected
   const [isLoading, setIsLoading] = useState(false)
   const { governancesArray } = useGovernanceAssets()
   const { current: connection } = useWalletStore((s) => s.connection)

--- a/pages/dao/[symbol]/proposal/components/NewProposalBtn.tsx
+++ b/pages/dao/[symbol]/proposal/components/NewProposalBtn.tsx
@@ -3,13 +3,14 @@ import { PlusCircleIcon } from '@heroicons/react/outline'
 import useQueryContext from '@hooks/useQueryContext'
 import useRealm from '@hooks/useRealm'
 import React from 'react'
-import useWalletStore from 'stores/useWalletStore'
 import Tooltip from '@components/Tooltip'
+import useWalletOnePointOh from '@hooks/useWalletOnePointOh'
 
 const NewProposalBtn = () => {
   const { fmtUrlWithCluster } = useQueryContext()
 
-  const connected = useWalletStore((s) => s.connected)
+  const wallet = useWalletOnePointOh()
+  const connected = !!wallet?.connected
 
   const {
     symbol,

--- a/pages/dao/[symbol]/treasury/index.tsx
+++ b/pages/dao/[symbol]/treasury/index.tsx
@@ -17,6 +17,7 @@ import Select from '@components/inputs/Select'
 import { getTreasuryAccountItemInfoV2 } from '@utils/treasuryTools'
 import { AssetAccount } from '@utils/uiTypes/assets'
 import Tooltip from '@components/Tooltip'
+import useWalletOnePointOh from '@hooks/useWalletOnePointOh'
 
 export const NEW_TREASURY_ROUTE = `/treasury/new`
 
@@ -37,7 +38,8 @@ const Treasury = () => {
   } = useRealm()
   const router = useRouter()
   const { fmtUrlWithCluster } = useQueryContext()
-  const connected = useWalletStore((s) => s.connected)
+  const wallet = useWalletOnePointOh()
+  const connected = !!wallet?.connected
   const [treasuryAccounts, setTreasuryAccounts] = useState<AssetAccount[]>([])
   const [activeAccount, setActiveAccount] = useState<AssetAccount | null>(null)
   const [accountInfo, setAccountInfo] = useState<any>(null)

--- a/pages/realms/index.tsx
+++ b/pages/realms/index.tsx
@@ -29,8 +29,8 @@ const Realms = () => {
   const [editingGrid, setEditingGrid] = useState(false)
   const { actions, selectedRealm } = useWalletStore((s) => s)
   const connection = useWalletStore((s) => s.connection)
-  const connected = useWalletStore((s) => s.connected)
   const wallet = useWalletOnePointOh()
+  const connected = !!wallet?.connected
   const router = useRouter()
   const { fmtUrlWithCluster } = useQueryContext()
   const [searchString, setSearchString] = useState('')

--- a/pages/realms/new/community-token/index.tsx
+++ b/pages/realms/new/community-token/index.tsx
@@ -105,9 +105,9 @@ const transformFormData2RealmCreation = (formData: CommunityTokenForm) => {
 }
 
 export default function CommunityTokenWizard() {
-  const connected = useWalletStore((s) => s.connected)
   const connection = useWalletStore((s) => s.connection)
   const wallet = useWalletOnePointOh()
+  const connected = !!wallet?.connected
   const { push } = useRouter()
   const { fmtUrlWithCluster } = useQueryContext()
   const [requestPending, setRequestPending] = useState(false)

--- a/pages/realms/new/multisig/index.tsx
+++ b/pages/realms/new/multisig/index.tsx
@@ -93,9 +93,9 @@ const transformMultisigForm2RealmCreation = ({ ...formData }: MultisigForm) => {
 }
 
 export default function MultiSigWizard() {
-  const connected = useWalletStore((s) => s.connected)
   const connection = useWalletStore((s) => s.connection)
   const wallet = useWalletOnePointOh()
+  const connected = !!wallet?.connected
   const { push } = useRouter()
   const { fmtUrlWithCluster } = useQueryContext()
   const [requestPending, setRequestPending] = useState(false)

--- a/pages/realms/new/nft/index.tsx
+++ b/pages/realms/new/nft/index.tsx
@@ -44,9 +44,9 @@ export const FORM_NAME = 'nft'
 type NFTForm = BasicDetails & AddNFTCollection & AddCouncil & InviteMembers
 
 export default function NFTWizard() {
-  const connected = useWalletStore((s) => s.connected)
   const connection = useWalletStore((s) => s.connection)
   const wallet = useWalletOnePointOh()
+  const connected = !!wallet?.connected
   const { push } = useRouter()
   const { fmtUrlWithCluster } = useQueryContext()
   const [requestPending, setRequestPending] = useState(false)

--- a/stores/useWalletStore.tsx
+++ b/stores/useWalletStore.tsx
@@ -47,7 +47,6 @@ import { getRealmConfigAccountOrDefault } from '@tools/governance/configs'
 import { getProposals } from '@utils/GovernanceTools'
 
 interface WalletStore extends State {
-  connected: boolean
   connection: ConnectionContext
   current: SignerWalletAdapter | undefined
 
@@ -129,7 +128,6 @@ const INITIAL_PROPOSAL_STATE = {
 } as const
 
 const useWalletStore = create<WalletStore>((set, get) => ({
-  connected: false,
   connection: getConnectionContext('mainnet'),
   current: undefined,
   realms: {},
@@ -185,8 +183,9 @@ const useWalletStore = create<WalletStore>((set, get) => ({
     },
     async fetchWalletTokenAccounts() {
       const connection = get().connection.current
-      const connected = get().connected
       const wallet = get().current
+      const connected = !!wallet?.connected
+
       const walletOwner = wallet?.publicKey
       const set = get().set
 
@@ -207,7 +206,8 @@ const useWalletStore = create<WalletStore>((set, get) => ({
     },
     async fetchDelegateVoteRecords() {
       const connection = get().connection.current
-      const connected = get().connected
+      const wallet = get().current
+      const connected = !!wallet?.connected
       const programId = get().selectedRealm.programId
       const realmId = get().selectedRealm.realm?.pubkey
       const selectedCouncilDelegate = get().selectedCouncilDelegate
@@ -253,11 +253,11 @@ const useWalletStore = create<WalletStore>((set, get) => ({
 
     async fetchOwnVoteRecords() {
       const connection = get().connection.current
-      const connected = get().connected
       const programId = get().selectedRealm.programId
       const realmId = get().selectedRealm.realm?.pubkey
       const realmMintPk = get().selectedRealm.realm?.account.communityMint
       const wallet = get().current
+      const connected = !!wallet?.connected
       const walletOwner = wallet?.publicKey
       const set = get().set
 


### PR DESCRIPTION
part of ongoing (and immediately needed) effort to modularize and dismantle useWalletStore. Here I just remove an extraneous connected component of the state, since you can just use the wallet adapter’s connected attribute instead and it’s just better to have one source of truth.