### PR TITLE
Agrippa/slightly-more-clear-stake-validator

### DIFF
--- a/pages/dao/[symbol]/proposal/components/instructions/Validators/StakeValidator.tsx
+++ b/pages/dao/[symbol]/proposal/components/instructions/Validators/StakeValidator.tsx
@@ -240,7 +240,7 @@ const StakeValidator = ({
         onChange={setValidatorVoteKey}
       />
       <Input
-        label="Seed for stake address (will be added with validator address)"
+        label="(optional, advanced) Seed for stake address"
         value={form.seed}
         error={formErrors['seed']}
         type="number"


### PR DESCRIPTION
<img width="665" alt="image" src="https://user-images.githubusercontent.com/12001874/230654035-457ae607-71f3-4f49-af49-335e176080c4.png">
Based on this user question I thought we could have a more clear label