### PR TITLE
Permit initial council member to be PDAs && Fix zeroCouncil checking

### DIFF
--- a/tools/governance/prepareRealmCreation.ts
+++ b/tools/governance/prepareRealmCreation.ts
@@ -146,7 +146,7 @@ export async function prepareRealmCreation({
   const councilMintAccount =
     existingCouncilMintPk &&
     (await tryGetMint(connection, existingCouncilMintPk))
-  const zeroCouncilTokenSupply = existingCommunityMintPk
+  const zeroCouncilTokenSupply = existingCouncilMintPk
     ? councilMintAccount?.account.supply.isZero()
     : true
   const councilMintHasMintAuthority = councilMintAccount

--- a/utils/textToAddressList.ts
+++ b/utils/textToAddressList.ts
@@ -1,4 +1,4 @@
-import { validateSolAddress } from '@utils/formValidation'
+import {validatePubkey} from '@utils/formValidation'
 
 export interface Addresses {
   valid: string[]
@@ -10,7 +10,7 @@ export const textToAddressList = (textBlock: string): Addresses => {
   const invalid: string[] = []
 
   textBlock.split(/[\s|,]/).forEach((address) => {
-    if (validateSolAddress(address)) {
+    if (validatePubkey(address)) {
       valid.push(address)
     } else if (address.trim() /* ignore empty strings */) {
       invalid.push(address.trim())


### PR DESCRIPTION
This change permit initial council members to be PDA (interesting if the member is a Squad)
Also but there was maybe a reason the zeroCouncilTokenSupply seems to use the wrong existing check `existingCommunityMintPk` vs `existingCouncilMintPk`