### PR TITLE
differentiate warning states in nft wiz

### DIFF
--- a/components/NewRealmWizard/components/steps/AddNFTCollectionForm.tsx
+++ b/components/NewRealmWizard/components/steps/AddNFTCollectionForm.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react'
+import { useEffect, useState } from 'react'
 import { useForm, Controller } from 'react-hook-form'
 import { yupResolver } from '@hookform/resolvers/yup'
 import * as yup from 'yup'
@@ -22,7 +22,6 @@ import AdviceBox from '@components/NewRealmWizard/components/AdviceBox'
 import NFTCollectionModal from '@components/NewRealmWizard/components/NFTCollectionModal'
 import { Metaplex } from '@metaplex-foundation/js'
 import { Connection, PublicKey } from '@solana/web3.js'
-import { getNFTsByCollection } from '@utils/tokens'
 import useWalletOnePointOh from '@hooks/useWalletOnePointOh'
 
 function filterAndMapVerifiedCollections(nfts) {
@@ -85,50 +84,13 @@ async function getNFTCollectionInfo(
   connection: Connection,
   collectionKey: string
 ) {
-  const collectionResult = await getNFTsByCollection(
-    new PublicKey(collectionKey)
-  )
-
-  const mintToCheck = collectionResult[0]?.mintAddress
-  if (!mintToCheck) {
-    throw new Error(
-      'Address did not return collection with children whose "collection.key" matched'
-    )
-  }
   const metaplex = new Metaplex(connection)
-  const metaplexData = await metaplex.nfts().findByMint({
-    mintAddress: new PublicKey(mintToCheck),
+  const data = await metaplex.nfts().findByMint({
+    mintAddress: new PublicKey(collectionKey),
   })
+  console.log('collection', collectionKey, data)
 
-  console.log('NFT findByMint result', metaplexData)
-  if (metaplexData?.collection?.verified && metaplexData.collection?.address) {
-    // here we were given a child of the collection (hence the "collection" property is present)
-    const collectionInfo = await enrichCollectionInfo(
-      connection,
-      metaplexData.collection.address.toBase58()
-    )
-    const nft = await enrichItemInfo(metaplexData, metaplexData.uri)
-    collectionInfo.nfts = [nft]
-    return collectionInfo
-  }
-  // assume we've been given the collection address already, so we need to go find it's children
-  const allNftsResult = collectionResult
-
-  const verifiedCollections = filterAndMapVerifiedCollections(allNftsResult)
-  if (verifiedCollections[collectionKey]) {
-    const collectionInfo = await enrichCollectionInfo(connection, collectionKey)
-    const nfts = await Promise.all(
-      verifiedCollections[collectionKey].map((item) => {
-        return enrichItemInfo(item, item.uri)
-      })
-    )
-    collectionInfo.nfts = nfts
-    return collectionInfo
-  } else {
-    throw new Error(
-      'Address did not return collection with children whose "collection.key" matched'
-    )
-  }
+  return [data, await enrichCollectionInfo(connection, collectionKey)] as const
 }
 
 export const AddNFTCollectionSchema = {
@@ -268,7 +230,12 @@ export default function AddNFTCollectionForm({
     mode: 'all',
     resolver: yupResolver(schema),
   })
-  const [unverifiedCollection, setUnverifiedCollection] = useState(false)
+  const [
+    collectionVerificationState,
+    setCollectionVerificationState,
+  ] = useState<
+    'none' | 'invalid' | 'verified' | 'is nft but no collection details'
+  >('none')
   const collectionKey = watch('collectionKey')
   const numberOfNFTs = watch('numberOfNFTs') || 10000
   const approvalPercent = watch('communityYesVotePercentage', 60) || 60
@@ -283,13 +250,13 @@ export default function AddNFTCollectionForm({
   }, [])
 
   useEffect(() => {
-    if (unverifiedCollection || selectedNFTCollection) {
+    if (collectionVerificationState === 'invalid' || selectedNFTCollection) {
       setFocus('numberOfNFTs')
     } else {
       // setFocus('collectionInput')
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps -- TODO please fix, it can cause difficult bugs. You might wanna check out https://bobbyhadz.com/blog/react-hooks-exhaustive-deps for info. -@asktree
-  }, [unverifiedCollection, selectedNFTCollection])
+  }, [collectionVerificationState, selectedNFTCollection])
 
   function serializeValues(values) {
     const data = {
@@ -308,18 +275,23 @@ export default function AddNFTCollectionForm({
       handleClearSelectedNFT(false)
       setRequestPending(true)
       try {
-        const collectionInfo = await getNFTCollectionInfo(
+        const [nft, collectionInfo] = await getNFTCollectionInfo(
           connection.current,
           collectionInput
         )
         console.log('NFT collection info from user input:', collectionInfo)
-        setValue('collectionKey', collectionInfo.collectionMintAddress)
+        setValue('collectionKey', collectionInput)
+        setCollectionVerificationState(
+          nft.collectionDetails !== null
+            ? 'verified'
+            : 'is nft but no collection details'
+        )
         setSelectedNFTCollection(collectionInfo)
         setRequestPending(false)
       } catch (err) {
         setRequestPending(false)
         setValue('collectionKey', collectionInput)
-        setUnverifiedCollection(true)
+        setCollectionVerificationState('invalid')
       }
     } else {
       setError('collectionInput', {
@@ -335,7 +307,7 @@ export default function AddNFTCollectionForm({
     }
     clearErrors('collectionInput')
     setValue('collectionKey', '')
-    setUnverifiedCollection(false)
+    setCollectionVerificationState('none')
     setSelectedNFTCollection(undefined)
   }
 
@@ -463,10 +435,15 @@ export default function AddNFTCollectionForm({
               <Input
                 placeholder="e.g. SMBH3wF6baUj6JWtzYvqcKuj2XCKWDqQxzspY12xPND"
                 data-testid="nft-address"
-                error={error?.message || ''}
+                error={
+                  error?.message ?? collectionVerificationState === 'invalid'
+                    ? 'Error: this is not an nft collection'
+                    : ''
+                }
                 warning={
-                  unverifiedCollection
-                    ? 'Caution: we could not verify this address is a "certified" collection.'
+                  collectionVerificationState ===
+                  'is nft but no collection details'
+                    ? 'Caution: this is an nft, but has no collection details. It may be an old collection, or just a regular nft. Please double check'
                     : ''
                 }
                 {...field}
@@ -503,7 +480,7 @@ export default function AddNFTCollectionForm({
         />
         <input className="hidden" {...register('collectionKey')} disabled />
 
-        {!unverifiedCollection && (
+        {collectionVerificationState === 'none' && (
           <div
             className={`flex flex-col w-full px-4 py-5 rounded-md bg-bkg-3  ${
               requestPending ? 'animate-pulse' : ''

--- a/components/NewRealmWizard/components/steps/AddNFTCollectionForm.tsx
+++ b/components/NewRealmWizard/components/steps/AddNFTCollectionForm.tsx
@@ -443,7 +443,7 @@ export default function AddNFTCollectionForm({
                 warning={
                   collectionVerificationState ===
                   'is nft but no collection details'
-                    ? 'Caution: This is an nft, but has no collection details. It may be an old collection, or just a regular nft. Please double check'
+                    ? 'Caution: This is an nft, but has no collection details. It may be an old collection, or just a regular nft. Please double check before proceeding.'
                     : ''
                 }
                 {...field}

--- a/components/NewRealmWizard/components/steps/AddNFTCollectionForm.tsx
+++ b/components/NewRealmWizard/components/steps/AddNFTCollectionForm.tsx
@@ -443,7 +443,7 @@ export default function AddNFTCollectionForm({
                 warning={
                   collectionVerificationState ===
                   'is nft but no collection details'
-                    ? 'Caution: this is an nft, but has no collection details. It may be an old collection, or just a regular nft. Please double check'
+                    ? 'Caution: This is an nft, but has no collection details. It may be an old collection, or just a regular nft. Please double check'
                     : ''
                 }
                 {...field}


### PR DESCRIPTION
We can't verify collection status for some old collections like smb that don't use the new standard. 
previous: ![image](https://user-images.githubusercontent.com/12001874/234371563-890869a7-0b39-4dd2-a18a-adfc0899f765.png)

I made it look like this instead: 
![image](https://user-images.githubusercontent.com/12001874/234371724-774b8cec-0f84-40d9-a75e-bf54573483e8.png)
Likewise I made the error stronger when we know it's definitely not a collection: 
![image](https://user-images.githubusercontent.com/12001874/234371777-2af98793-d326-4b76-820d-12986607a830.png)
