### PR TITLE
Agrippa/fix-nft-client-withdrawl

### DIFF
--- a/components/Members/MemberOverview.tsx
+++ b/components/Members/MemberOverview.tsx
@@ -113,7 +113,6 @@ const MemberOverview = ({ member }: { member: Member }) => {
     walletAddress,
     councilVotes,
     communityVotes,
-    votesCasted,
     hasCouncilTokenOutsideRealm,
     hasCommunityTokenOutsideRealm,
   } = member
@@ -321,7 +320,9 @@ const MemberOverview = ({ member }: { member: Member }) => {
         )}
         <div className="bg-bkg-1 px-4 py-2 rounded-md w-full break-all">
           <p>Votes Cast</p>
-          <div className="font-bold text-fgd-1 text-2xl">{votesCasted}</div>
+          <div className="font-bold text-fgd-1 text-2xl">
+            {ownVoteRecords.length}
+          </div>
           <div className="flex">
             <p>
               Yes Votes:{' '}

--- a/components/Members/MembersTabs.tsx
+++ b/components/Members/MembersTabs.tsx
@@ -80,7 +80,6 @@ const MemberItems = ({
     walletAddress,
     councilVotes,
     communityVotes,
-    votesCasted,
     hasCommunityTokenOutsideRealm,
     hasCouncilTokenOutsideRealm,
   } = member
@@ -137,7 +136,6 @@ const MemberItems = ({
         </div>
         <div>
           <h3 className="flex mb-1 text-base font-bold">{renderAddressName}</h3>
-          <p className="mb-0 text-xs text-fgd-1">Votes Cast: {votesCasted}</p>
           <span className="text-xs text-fgd-3">
             {(communityAmount || !councilAmount) && (
               <span className="flex items-center">

--- a/components/Members/MembersTabs.tsx
+++ b/components/Members/MembersTabs.tsx
@@ -136,6 +136,7 @@ const MemberItems = ({
         </div>
         <div>
           <h3 className="flex mb-1 text-base font-bold">{renderAddressName}</h3>
+          {/* <p className="mb-0 text-xs text-fgd-1">Votes Cast: {votesCasted}</p> */}
           <span className="text-xs text-fgd-3">
             {(communityAmount || !councilAmount) && (
               <span className="flex items-center">

--- a/components/Members/useMembers.tsx
+++ b/components/Members/useMembers.tsx
@@ -180,12 +180,10 @@ export default function useMembers() {
                       : acc.councilVotes,
                   }
                   if (curr.community) {
-                    obj.votesCasted += curr.community.account.totalVotesCount
                     obj.delegateWalletCommunity =
                       curr.community.account.governanceDelegate
                   }
                   if (curr.council) {
-                    obj.votesCasted += curr.council.account.totalVotesCount
                     obj.delegateWalletCouncil =
                       curr.council.account.governanceDelegate
                   }
@@ -193,14 +191,13 @@ export default function useMembers() {
                 },
                 {
                   walletAddress: '',
-                  votesCasted: 0,
                   councilVotes: BN_ZERO,
                   communityVotes: BN_ZERO,
                 }
               ),
           }
         })
-        .sort((a, b) => a.votesCasted - b.votesCasted)
+        // .sort((a, b) => a.votesCasted - b.votesCasted)
         .reverse(),
 
     // eslint-disable-next-line react-hooks/exhaustive-deps -- TODO please fix, it can cause difficult bugs. You might wanna check out https://bobbyhadz.com/blog/react-hooks-exhaustive-deps for info. -@asktree

--- a/utils/uiTypes/VotePlugin.ts
+++ b/utils/uiTypes/VotePlugin.ts
@@ -9,7 +9,6 @@ import {
   SYSTEM_PROGRAM_ID,
   Proposal,
   TokenOwnerRecord,
-  getVoterWeightRecord,
 } from '@solana/spl-governance'
 import { PublicKey, TransactionInstruction } from '@solana/web3.js'
 import { chunks } from '@utils/helpers'

--- a/utils/uiTypes/VotePlugin.ts
+++ b/utils/uiTypes/VotePlugin.ts
@@ -663,8 +663,7 @@ export class VotingClient {
       // But we're not writing good code, there's no good place for it, I'm not bothering.
       const voterWeightRecord = await queryClient.fetchQuery({
         queryKey: [voterWeightPk],
-        queryFn: () =>
-          asFindable(getVoterWeightRecord)(connection, voterWeightPk),
+        queryFn: () => asFindable(connection.getAccountInfo)(voterWeightPk),
       })
       if (voterWeightRecord.result) {
         const firstFiveNfts = remainingAccounts.slice(0, 5)

--- a/utils/uiTypes/VotePlugin.ts
+++ b/utils/uiTypes/VotePlugin.ts
@@ -9,6 +9,7 @@ import {
   SYSTEM_PROGRAM_ID,
   Proposal,
   TokenOwnerRecord,
+  getVoterWeightRecord,
 } from '@solana/spl-governance'
 import { PublicKey, TransactionInstruction } from '@solana/web3.js'
 import { chunks } from '@utils/helpers'
@@ -46,6 +47,8 @@ import { getUsedPositionsForProposal } from 'HeliumVotePlugin/utils/getUsedPosit
 import { getConnectionContext } from '@utils/connection'
 import { getAssociatedTokenAddress } from '@blockworks-foundation/mango-v4'
 import { NftVoterClient } from './NftVoterClient'
+import queryClient from '@hooks/queries/queryClient'
+import asFindable from '@utils/queries/asFindable'
 
 type UpdateVoterWeightRecordTypes =
   | 'castVote'
@@ -654,30 +657,39 @@ export class VotingClient {
           new AccountData(voteRecord.publicKey, false, true)
         )
       }
+      const connection = this.client.program.provider.connection
 
-      const firstFiveNfts = remainingAccounts.slice(0, 5)
-      const remainingNftsChunk = chunks(
-        remainingAccounts.slice(5, remainingAccounts.length),
-        12
-      )
-
-      for (const chunk of [firstFiveNfts, ...remainingNftsChunk]) {
-        instructions.push(
-          await this.client.program.methods
-            .relinquishNftVote()
-            .accounts({
-              registrar,
-              voterWeightRecord: voterWeightPk,
-              governance: proposal.account.governance,
-              proposal: proposal.pubkey,
-              voterTokenOwnerRecord: tokenOwnerRecord,
-              voterAuthority: walletPk,
-              voteRecord: voteRecordPk,
-              beneficiary: walletPk,
-            })
-            .remainingAccounts(chunk)
-            .instruction()
+      const voterWeightRecord = await queryClient.fetchQuery({
+        queryKey: [voterWeightPk],
+        queryFn: () =>
+          asFindable(getVoterWeightRecord)(connection, voterWeightPk),
+      })
+      console.log(voterWeightRecord)
+      if (voterWeightRecord.result) {
+        const firstFiveNfts = remainingAccounts.slice(0, 5)
+        const remainingNftsChunk = chunks(
+          remainingAccounts.slice(5, remainingAccounts.length),
+          12
         )
+
+        for (const chunk of [firstFiveNfts, ...remainingNftsChunk]) {
+          instructions.push(
+            await this.client.program.methods
+              .relinquishNftVote()
+              .accounts({
+                registrar,
+                voterWeightRecord: voterWeightPk,
+                governance: proposal.account.governance,
+                proposal: proposal.pubkey,
+                voterTokenOwnerRecord: tokenOwnerRecord,
+                voterAuthority: walletPk,
+                voteRecord: voteRecordPk,
+                beneficiary: walletPk,
+              })
+              .remainingAccounts(chunk)
+              .instruction()
+          )
+        }
       }
 
       return { voterWeightPk, maxVoterWeightRecord }

--- a/utils/uiTypes/VotePlugin.ts
+++ b/utils/uiTypes/VotePlugin.ts
@@ -659,6 +659,8 @@ export class VotingClient {
       }
       const connection = this.client.program.provider.connection
 
+      // if this was good code, this would appear outside of this fn.
+      // But we're not writing good code, there's no good place for it, I'm not bothering.
       const voterWeightRecord = await queryClient.fetchQuery({
         queryKey: [voterWeightPk],
         queryFn: () =>

--- a/utils/uiTypes/VotePlugin.ts
+++ b/utils/uiTypes/VotePlugin.ts
@@ -666,7 +666,6 @@ export class VotingClient {
         queryFn: () =>
           asFindable(getVoterWeightRecord)(connection, voterWeightPk),
       })
-      console.log(voterWeightRecord)
       if (voterWeightRecord.result) {
         const firstFiveNfts = remainingAccounts.slice(0, 5)
         const remainingNftsChunk = chunks(

--- a/utils/uiTypes/members.ts
+++ b/utils/uiTypes/members.ts
@@ -3,7 +3,6 @@ import { PublicKey } from '@solana/web3.js'
 
 export interface Member {
   walletAddress: string
-  votesCasted: number
   councilVotes: BN
   communityVotes: BN
   hasCouncilTokenOutsideRealm?: boolean


### PR DESCRIPTION
We have a bug where if you vote without plugins, then add nft plugins, then try to relinquish all your votes, you get an error. My solution was to make `relinquishVote` for the NFT client check if you have a voteWeightRecord before attempting.

This is not the most parsimonious solution, but it's the one that involves editing the least amount of code. This bug may exist for other plugins. I would hope to have rewritten all of the affecting code by the time it ever comes up again.