### PR TITLE
KILL "Uncharted Daos" list on homepage

### DIFF
--- a/models/registry/api.ts
+++ b/models/registry/api.ts
@@ -49,6 +49,7 @@ export interface RealmInfo {
   communityMint?: PublicKey
 }
 
+/** @deprecated */
 export function getProgramVersionForRealm(realmInfo: RealmInfo) {
   // TODO: as a temp fix V1 is returned by default
   return realmInfo?.programVersion ?? PROGRAM_VERSION_V1
@@ -71,6 +72,7 @@ interface RealmInfoAsJSON
 const MAINNET_REALMS = parseCertifiedRealms(mainnetBetaRealms)
 const DEVNET_REALMS = parseCertifiedRealms(devnetRealms)
 
+/** @deprecated */
 function parseCertifiedRealms(realms: RealmInfoAsJSON[]) {
   return realms.map((realm) => ({
     ...realm,
@@ -90,7 +92,7 @@ function parseCertifiedRealms(realms: RealmInfoAsJSON[]) {
 export function getCertifiedRealmInfos({ cluster }: ConnectionContext) {
   return cluster === 'devnet' ? DEVNET_REALMS : MAINNET_REALMS
 }
-
+/** @deprecated */
 export function getCertifiedRealmInfo(
   realmId: string,
   connection: ConnectionContext
@@ -176,6 +178,7 @@ const EXCLUDED_REALMS = new Map<string, string>([
 ])
 
 // Returns all known realms from all known spl-gov instances which are not certified
+/** @deprecated */
 export async function getUnchartedRealmInfos(connection: ConnectionContext) {
   const certifiedRealms = getCertifiedRealmInfos(connection)
 
@@ -214,7 +217,7 @@ export async function getUnchartedRealmInfos(connection: ConnectionContext) {
     })
     .filter(Boolean) as readonly RealmInfo[]
 }
-
+/** @deprecated */
 export function createUnchartedRealmInfo(realm: UnchartedRealm) {
   return {
     symbol: realm.name,

--- a/pages/realms/components/RealmsGrid.tsx
+++ b/pages/realms/components/RealmsGrid.tsx
@@ -69,7 +69,7 @@ const RealmBox = React.forwardRef<HTMLDivElement, IRealmBox>(
 
 function RealmsGrid({
   certifiedRealms,
-  unchartedRealms,
+  //unchartedRealms,
   filteredRealms,
   editing,
   searching,

--- a/pages/realms/components/RealmsGrid.tsx
+++ b/pages/realms/components/RealmsGrid.tsx
@@ -290,7 +290,7 @@ function RealmsGrid({
                   )
               )}
           </div>
-          <h2 className="pt-12 mb-4">Uncharted DAOs</h2>
+          {/* <h2 className="pt-12 mb-4">Uncharted DAOs</h2>
           <div className="grid grid-flow-row grid-cols-2 gap-4 md:grid-cols-3 lg:grid-cols-5">
             {unchartedRealms &&
               unchartedRealms.map(
@@ -309,7 +309,7 @@ function RealmsGrid({
                     </div>
                   )
               )}
-          </div>
+          </div> */}
         </div>
       )}
     </>

--- a/pages/realms/index.tsx
+++ b/pages/realms/index.tsx
@@ -43,11 +43,16 @@ const Realms = () => {
       connection &&
       ((routeHasClusterInPath && cluster) || !routeHasClusterInPath)
     ) {
-      const [certifiedRealms, uncharteredRealms] = await Promise.all([
+      const [
+        certifiedRealms, //uncharteredRealms
+      ] = await Promise.all([
         getCertifiedRealmInfos(connection),
-        getUnchartedRealmInfos(connection),
+        // getUnchartedRealmInfos(connection),
       ])
-      const allRealms = [...certifiedRealms, ...uncharteredRealms]
+      const allRealms = [
+        ...certifiedRealms,
+        //...uncharteredRealms
+      ]
       setRealms(sortDaos(allRealms))
       setFilteredRealms(sortDaos(allRealms))
       setIsLoadingRealms(false)

--- a/pages/realms/index.tsx
+++ b/pages/realms/index.tsx
@@ -1,10 +1,6 @@
-import React, { useMemo, useState } from 'react'
+import { useMemo, useState } from 'react'
 
-import {
-  getCertifiedRealmInfos,
-  getUnchartedRealmInfos,
-  RealmInfo,
-} from '../../models/registry/api'
+import { getCertifiedRealmInfos, RealmInfo } from '../../models/registry/api'
 
 import { SearchIcon } from '@heroicons/react/outline'
 import useWalletStore from '../../stores/useWalletStore'


### PR DESCRIPTION
Before this PR, the home page (`/realms`) looked like this: 
<img width="1147" alt="image" src="https://github.com/solana-labs/governance-ui/assets/12001874/931e5538-dbbb-4981-afc7-2b431cac1e69">
After this PR, it looks like this: 
<img width="1147" alt="image" src="https://github.com/solana-labs/governance-ui/assets/12001874/08b80d2b-74b1-4d2e-8bde-3956ec01ccfc">
Except that it loads immediately instead of after several minutes / never due to 429 error from RPC.

The difference is that in the previous case if you scrolled down far enough you would find "Uncharted Daos" which were all DAOs we could find that aren't in our JSON files. Most of them are just test daos. The only actual important difference is that you could use the search bar to search them, but I don't think this is a very big deal. 

The reason it performed so badly is because it was performing hundreds of GPA calls. Why? I will never know, because there is no possible reason to do this. I was in the process of fixing it, when I determined this component probably shouldn't exist at all. Probably the homepage should only show whitelisted DAOs. 