### PR TITLE
Fix bug in our Select component

### DIFF
--- a/components/chat/DiscussionPanel.tsx
+++ b/components/chat/DiscussionPanel.tsx
@@ -1,17 +1,18 @@
-import React, { useMemo } from 'react'
+import { useMemo } from 'react'
 import DiscussionForm from './DiscussionForm'
 import Comment from './Comment'
 import { useQuery } from '@tanstack/react-query'
-import { PublicKey } from '@solana/web3.js'
 import {
   GOVERNANCE_CHAT_PROGRAM_ID,
   getGovernanceChatMessages,
 } from '@solana/spl-governance'
 import { useProposalVoteRecordQuery } from '@hooks/queries/voteRecord'
 import useLegacyConnectionContext from '@hooks/useLegacyConnectionContext'
+import { useSelectedProposalPk } from '@hooks/queries/proposal'
 
-export const useChatMessagesByProposalQuery = (proposalPk?: PublicKey) => {
+export const useChatMessagesQuery = () => {
   const connection = useLegacyConnectionContext()
+  const proposalPk = useSelectedProposalPk()
 
   const enabled = proposalPk !== undefined
   const query = useQuery({
@@ -33,8 +34,10 @@ export const useChatMessagesByProposalQuery = (proposalPk?: PublicKey) => {
 }
 
 const DiscussionPanel = () => {
-  const { data: chatMessages } = useChatMessagesByProposalQuery()
+  const { data: chatMessages } = useChatMessagesQuery()
   const { data: voteRecord } = useProposalVoteRecordQuery('electoral')
+
+  console.log('borp', chatMessages)
 
   const sortedMessages = useMemo(
     () =>

--- a/components/inputs/Select.tsx
+++ b/components/inputs/Select.tsx
@@ -2,7 +2,12 @@ import { Listbox } from '@headlessui/react'
 import { ChevronDownIcon } from '@heroicons/react/solid'
 import { StyledLabel, inputClasses } from './styles'
 import ErrorField from './ErrorField'
+import React from 'react'
 
+/**
+ * @deprecated
+ * doesn't really have a replacement but needs one
+ */
 const Select = ({
   value,
   onChange,
@@ -28,7 +33,7 @@ const Select = ({
   disabled?: boolean | undefined
   label?: string | undefined
   subtitle?: string | undefined
-  componentLabel?: any | undefined
+  componentLabel?: React.ReactNode
   useDefaultStyle?: boolean
   noMaxWidth?: boolean
   wrapperClassNames?: string
@@ -61,7 +66,7 @@ const Select = ({
                 >
                   {componentLabel
                     ? componentLabel
-                    : value
+                    : React.isValidElement(value)
                     ? value
                     : placeholder}
                   <ChevronDownIcon


### PR DESCRIPTION
`Select` accepts anything as a `value`, but can try to display the `value` in DOM under certain circumstances. This causes a crash. Ideally `Select` should not have this API, but for now I just made sure we don't try to display things that aren't valid JSX elements (which was the case in GovernedAccountSelect if `governedAccounts` was `[]`)