### PR TITLE
Agrippa/token-accounts-query-spam

### DIFF
--- a/components/NftVotingCountingModal.tsx
+++ b/components/NftVotingCountingModal.tsx
@@ -47,7 +47,8 @@ const NftVotingComponent = () => {
   }, [usedNfts, remainingNftsToCount])
 
   useEffect(() => {
-    const multiplier = processedTransactions - prevProcessedTransactions
+    const multiplier =
+      processedTransactions - (prevProcessedTransactions as number)
     if (processedTransactions !== 0) {
       if (remainingVotingPower <= lastTransactionNftsCount) {
         handleCalcCountedNfts(remainingVotingPower)

--- a/hooks/handleGovernanceAssetsStore.ts
+++ b/hooks/handleGovernanceAssetsStore.ts
@@ -1,4 +1,4 @@
-import { useEffect, useMemo } from 'react'
+import { useEffect } from 'react'
 import useGovernanceAssetsStore from 'stores/useGovernanceAssetsStore'
 import { useRealmQuery } from './queries/realm'
 import { useRealmGovernancesQuery } from './queries/governance'

--- a/hooks/handleGovernanceAssetsStore.ts
+++ b/hooks/handleGovernanceAssetsStore.ts
@@ -10,17 +10,12 @@ export default function useHandleGovernanceAssetsStore() {
   const connection = useLegacyConnectionContext()
 
   const governancesArray = useRealmGovernancesQuery().data
-  const governancesByGovernance = useMemo(
-    () =>
-      governancesArray &&
-      Object.fromEntries(governancesArray.map((x) => [x.pubkey.toString(), x])),
-    [governancesArray]
-  )
+
   const { setGovernancesArray } = useGovernanceAssetsStore()
 
   useEffect(() => {
-    if (realm && governancesByGovernance) {
-      setGovernancesArray(connection, realm, governancesByGovernance)
+    if (realm && governancesArray) {
+      setGovernancesArray(connection, realm, governancesArray)
     }
-  }, [connection, governancesByGovernance, realm, setGovernancesArray])
+  }, [connection, governancesArray, realm, setGovernancesArray])
 }

--- a/hooks/usePrevious.ts
+++ b/hooks/usePrevious.ts
@@ -1,9 +1,39 @@
 import { useEffect, useRef } from 'react'
 
-export function usePrevious(value) {
-  const ref = useRef()
+export function usePrevious<T>(value: T, initialValue?: T) {
+  const ref = useRef(initialValue)
   useEffect(() => {
     ref.current = value
   })
-  return ref.current as any
+  return ref.current
+}
+
+export const useEffectDebugger = (
+  effectHook,
+  dependencies,
+  dependencyNames = []
+) => {
+  const previousDeps = usePrevious(dependencies, [])
+
+  const changedDeps = dependencies.reduce((accum, dependency, index) => {
+    if (dependency !== previousDeps[index]) {
+      const keyName = dependencyNames[index] || index
+      return {
+        ...accum,
+        [keyName]: {
+          before: previousDeps[index],
+          after: dependency,
+        },
+      }
+    }
+
+    return accum
+  }, {})
+
+  if (Object.keys(changedDeps).length) {
+    console.log('[use-effect-debugger] ', changedDeps)
+  }
+
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  useEffect(effectHook, dependencies)
 }

--- a/pages/dao/[symbol]/params/index.tsx
+++ b/pages/dao/[symbol]/params/index.tsx
@@ -28,6 +28,7 @@ import useWalletOnePointOh from '@hooks/useWalletOnePointOh'
 import { useRealmQuery } from '@hooks/queries/realm'
 import { useRealmConfigQuery } from '@hooks/queries/realmConfig'
 import { useRealmCommunityMintInfoQuery } from '@hooks/queries/mintInfo'
+import { useRealmGovernancesQuery } from '@hooks/queries/governance'
 
 const Params = () => {
   const mint = useRealmCommunityMintInfoQuery().data?.result
@@ -43,12 +44,12 @@ const Params = () => {
     assetAccounts,
     auxiliaryTokenAccounts,
   } = useGovernanceAssets()
-  const governancesArray = useGovernanceAssetsStore((s) => s.governancesArray)
+  const governancesArray = useRealmGovernancesQuery().data
   const mintGovernancesWithMintInfo = assetAccounts.filter((x) => {
     return x.type === AccountType.MINT
   })
 
-  const hasAuthorityGovernances = governancesArray.filter((governance) => {
+  const hasAuthorityGovernances = governancesArray?.filter((governance) => {
     const filteredMintGovernances = mintGovernancesWithMintInfo.filter(
       (mintGovernance) =>
         mintGovernance.governance.pubkey.toString() ===
@@ -64,12 +65,12 @@ const Params = () => {
       governance.pubkey.toString()
     )
   })
-  const showCreateMetadataButton = !!hasAuthorityGovernances.length
+  const showCreateMetadataButton = !!hasAuthorityGovernances?.length
   const loadGovernedAccounts = useGovernanceAssetsStore(
     (s) => s.loadGovernedAccounts
   )
 
-  const realmAuthorityGovernance = governancesArray.find(
+  const realmAuthorityGovernance = governancesArray?.find(
     (x) => x.pubkey.toBase58() === realm?.account.authority?.toBase58()
   )
 
@@ -111,7 +112,7 @@ const Params = () => {
         fmtMintAmount(mint, realmConfig.minCommunityTokensToCreateGovernance)
 
   useEffect(() => {
-    if (governancesArray.length > 0) {
+    if (governancesArray !== undefined && governancesArray.length > 0) {
       setActiveGovernance(governancesArray[0])
     }
   }, [governancesArray])
@@ -272,7 +273,7 @@ const Params = () => {
             </>
           )}
         </div>
-        {!loadGovernedAccounts ? (
+        {!loadGovernedAccounts && governancesArray !== undefined ? (
           <>
             <div className="grid grid-cols-12 gap-4 p-6 mb-6 border rounded-md border-fgd-4 lg:gap-6">
               <div className="col-span-12 lg:hidden">

--- a/pages/dao/[symbol]/token-stats/index.tsx
+++ b/pages/dao/[symbol]/token-stats/index.tsx
@@ -13,7 +13,7 @@ import { PublicKey } from '@solana/web3.js'
 import { getMintDecimalAmount } from '@tools/sdk/units'
 import dayjs from 'dayjs'
 import dynamic from 'next/dynamic'
-import { useEffect, useRef, useState } from 'react'
+import { useEffect, useMemo, useRef, useState } from 'react'
 import useGovernanceAssetsStore from 'stores/useGovernanceAssetsStore'
 import useVotePluginsClientStore from 'stores/useVotePluginsClientStore'
 import {
@@ -106,10 +106,14 @@ const LockTokenStats = () => {
     (acc, curr) => acc.add(curr.amount!),
     new BN(0)
   )
-  const possibleGrantProposals = proposals?.filter(
-    (x) =>
-      x.account.governance.toBase58() === MANGO_DAO_TREASURY &&
-      x.account.accountType === GovernanceAccountType.ProposalV2
+  const possibleGrantProposals = useMemo(
+    () =>
+      proposals?.filter(
+        (x) =>
+          x.account.governance.toBase58() === MANGO_DAO_TREASURY &&
+          x.account.accountType === GovernanceAccountType.ProposalV2
+      ),
+    [proposals]
   )
   const currentMonthName = statsMonths.length ? statsMonths[0] : ''
   const vestingThisMonth =
@@ -292,6 +296,7 @@ const LockTokenStats = () => {
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps -- TODO please fix, it can cause difficult bugs. You might wanna check out https://bobbyhadz.com/blog/react-hooks-exhaustive-deps for info. -@asktree
   }, [possibleGrantProposals, realmInfo?.programId])
+
   useEffect(() => {
     const depositsWithWalletsInner: DepositWithWallet[] = []
     for (const voter of voters) {

--- a/stores/useGovernanceAssetsStore.tsx
+++ b/stores/useGovernanceAssetsStore.tsx
@@ -85,9 +85,7 @@ interface GovernanceAssetsStore extends State {
   setGovernancesArray: (
     connection: ConnectionContext,
     realm: ProgramAccount<Realm>,
-    governances: {
-      [governance: string]: ProgramAccount<Governance>
-    }
+    governances: ProgramAccount<Governance>[]
   ) => void
   getGovernedAccounts: (
     connection: ConnectionContext,
@@ -116,13 +114,11 @@ const useGovernanceAssetsStore = create<GovernanceAssetsStore>((set, _get) => ({
   setGovernancesArray: (
     connection: ConnectionContext,
     realm: ProgramAccount<Realm>,
-    governances: {
-      [governance: string]: ProgramAccount<Governance>
-    }
+    governances: ProgramAccount<Governance>[]
   ) => {
-    const array: ProgramAccount<Governance>[] = Object.keys(governances)
-      .filter((gpk) => !HIDDEN_GOVERNANCES.has(gpk))
-      .map((key) => governances[key])
+    const array: ProgramAccount<Governance>[] = governances.filter(
+      (gov) => !HIDDEN_GOVERNANCES.has(gov.pubkey.toString())
+    )
 
     set((s) => {
       s.governancesArray = array


### PR DESCRIPTION
this pr fixes spam useEffect in the token-stats page. I had an unMemo'd `array.filter` and the linter didn't catch, apparently it doesn't catch these if you don't have exhaustive deps of the hook, which is kinda dumb if you ask me.