### PR TITLE
fix css in NFT selector such that items compressed

### DIFF
--- a/components/NFTS/NFTSelector.tsx
+++ b/components/NFTS/NFTSelector.tsx
@@ -108,7 +108,7 @@ function NFTSelector(
                 <div
                   onClick={() => (selectable ? handleSelectNft(x) : null)}
                   key={x.mintAddress}
-                  className={`bg-bkg-2 flex items-center justify-center cursor-pointer default-transition rounded-lg border border-transparent ${
+                  className={`bg-bkg-2 flex-shrink-0 flex items-center justify-center cursor-pointer default-transition rounded-lg border border-transparent ${
                     selectable ? 'hover:border-primary-dark' : ''
                   } relative overflow-hidden`}
                   style={{


### PR DESCRIPTION
previously if you had a ton of NFTs then they would each take, for example, 2px width in the flexbox for this component. which was unusable.

I would like to thank firefox flexbox tools for making this easy to debug.