### PR TITLE
update create metadata instruction to v3

### DIFF
--- a/utils/instructionTools.ts
+++ b/utils/instructionTools.ts
@@ -28,7 +28,7 @@ import { UiInstruction } from './uiTypes/proposalCreationTypes'
 import { AssetAccount } from '@utils/uiTypes/assets'
 import {
   createCreateMetadataAccountV3Instruction,
-  createUpdateMetadataAccountV2Instruction
+  createUpdateMetadataAccountV2Instruction,
 } from '@metaplex-foundation/mpl-token-metadata'
 import { findMetadataPda } from '@metaplex-foundation/js'
 import { lidoStake } from '@utils/lidoStake'
@@ -600,7 +600,7 @@ export async function getCreateTokenMetadataInstruction({
       },
       {
         createMetadataAccountArgsV3: {
-          collectionDetails: null,
+          collectionDetails: null, // note: likely this field should be supported by the forms, but I don't know what it does
           data: tokenMetadata,
           isMutable: true,
         },

--- a/utils/instructionTools.ts
+++ b/utils/instructionTools.ts
@@ -27,8 +27,8 @@ import { isFormValid } from './formValidation'
 import { UiInstruction } from './uiTypes/proposalCreationTypes'
 import { AssetAccount } from '@utils/uiTypes/assets'
 import {
-  createCreateMetadataAccountV2Instruction,
-  createUpdateMetadataAccountV2Instruction,
+  createCreateMetadataAccountV3Instruction,
+  createUpdateMetadataAccountV2Instruction
 } from '@metaplex-foundation/mpl-token-metadata'
 import { findMetadataPda } from '@metaplex-foundation/js'
 import { lidoStake } from '@utils/lidoStake'
@@ -590,7 +590,7 @@ export async function getCreateTokenMetadataInstruction({
       prerequisiteInstructions.push(preTransferIx)
     }
 
-    const transferIx = createCreateMetadataAccountV2Instruction(
+    const transferIx = createCreateMetadataAccountV3Instruction(
       {
         metadata: metadataPDA,
         mint: form.mintAccount?.pubkey,
@@ -599,7 +599,8 @@ export async function getCreateTokenMetadataInstruction({
         updateAuthority: mintAuthority,
       },
       {
-        createMetadataAccountArgsV2: {
+        createMetadataAccountArgsV3: {
+          collectionDetails: null,
           data: tokenMetadata,
           isMutable: true,
         },


### PR DESCRIPTION
Metaplex updated their program https://docs.metaplex.com/programs/token-metadata/changelog/v1.3#new-instructions

test proposal:
http://localhost:3000/dao/2oe5dGpX4wers8qoAFMbUxogg68bmA9P65n7cB9716YZ/proposal/5Dk5Wt6pz63Yv3Ue3igwNZBXtyJjYnr9Vvdijx5CGEmU?cluster=devnet