### PR TITLE
finish killing nft stuff in useTreasuryAccountStore

### DIFF
--- a/components/App.tsx
+++ b/components/App.tsx
@@ -6,7 +6,6 @@ import Head from 'next/head'
 import Script from 'next/script'
 import { useRouter } from 'next/router'
 import { GatewayProvider } from '@components/Gateway/GatewayProvider'
-import { usePrevious } from '@hooks/usePrevious'
 import { useVotingPlugins } from '@hooks/useVotingPlugins'
 import { VSR_PLUGIN_PKS } from '@constants/plugins'
 import ErrorBoundary from '@components/ErrorBoundary'
@@ -17,9 +16,7 @@ import PageBodyContainer from '@components/PageBodyContainer'
 import tokenPriceService from '@utils/services/tokenPrice'
 import TransactionLoader from '@components/TransactionLoader'
 import useDepositStore from 'VoteStakeRegistry/stores/useDepositStore'
-import useGovernanceAssets from '@hooks/useGovernanceAssets'
 import useRealm from '@hooks/useRealm'
-import useTreasuryAccountStore from 'stores/useTreasuryAccountStore'
 import useVotePluginsClientStore from 'stores/useVotePluginsClientStore'
 import NftVotingCountingModal from '@components/NftVotingCountingModal'
 import { getResourcePathPart } from '@tools/core/resources'
@@ -103,12 +100,7 @@ export function AppContents(props: Props) {
   useEffect(() => {
     tokenPriceService.fetchSolanaTokenList()
   }, [])
-  const { governedTokenAccounts } = useGovernanceAssets()
-  const possibleNftsAccounts = useMemo(
-    () => governedTokenAccounts.filter((x) => x.isSol || x.isNft),
-    [governedTokenAccounts]
-  )
-  const { getNfts } = useTreasuryAccountStore()
+
   const { getOwnedDeposits, resetDepositState } = useDepositStore()
 
   const ownTokenRecord = useUserCommunityTokenOwnerRecord().data?.result
@@ -119,9 +111,7 @@ export function AppContents(props: Props) {
   const wallet = useWalletOnePointOh()
   const connection = useLegacyConnectionContext()
   const vsrClient = useVotePluginsClientStore((s) => s.state.vsrClient)
-  const prevStringifyPossibleNftsAccounts = usePrevious(
-    JSON.stringify(possibleNftsAccounts)
-  )
+
   const router = useRouter()
   const { cluster, symbol } = router.query
   const updateSerumGovAccounts = useSerumGovStore(
@@ -172,22 +162,6 @@ export function AppContents(props: Props) {
     resetDepositState,
     vsrClient,
     wallet?.connected,
-  ])
-
-  useEffect(() => {
-    if (
-      prevStringifyPossibleNftsAccounts !==
-        JSON.stringify(possibleNftsAccounts) &&
-      realm?.pubkey
-    ) {
-      getNfts(possibleNftsAccounts, connection)
-    }
-  }, [
-    connection,
-    getNfts,
-    possibleNftsAccounts,
-    prevStringifyPossibleNftsAccounts,
-    realm?.pubkey,
   ])
 
   useEffect(() => {

--- a/components/NFTS/NFTSCompactWrapper.tsx
+++ b/components/NFTS/NFTSCompactWrapper.tsx
@@ -1,14 +1,17 @@
 import { ChevronRightIcon } from '@heroicons/react/solid'
-import useGovernanceAssets from '@hooks/useGovernanceAssets'
+import { useRealmDigitalAssetsQuery } from '@hooks/queries/digitalAssets'
 import useQueryContext from '@hooks/useQueryContext'
-import useRealm from '@hooks/useRealm'
+import { useRouter } from 'next-router-mock'
 import Link from 'next/link'
+import { useMemo } from 'react'
 
 const NFTSCompactWrapper = () => {
-  const { nftsGovernedTokenAccounts } = useGovernanceAssets()
-  const { symbol } = useRealm()
+  const { data: nfts } = useRealmDigitalAssetsQuery()
+  const nftsCount = useMemo(() => nfts?.flat().length ?? 0, [nfts])
+
+  const { symbol } = useRouter().query
   const { fmtUrlWithCluster } = useQueryContext()
-  return nftsGovernedTokenAccounts.length ? (
+  return nftsCount > 0 ? (
     <div className="bg-bkg-2 p-4 md:p-6 rounded-lg transition-all">
       <div className="flex items-center justify-between">
         <h3 className="mb-0">NFTs</h3>

--- a/components/TokenBalance/DelegateTokenBalanceCard.tsx
+++ b/components/TokenBalance/DelegateTokenBalanceCard.tsx
@@ -63,10 +63,13 @@ const DelegateBalanceCard = () => {
     )
   }
 
+  console.log('councilTorsDelegatedToUser', councilTorsDelegatedToUser)
+
   const hasDelegators =
-    communityTorsDelegatedToUser?.length ??
-    (0 > 0 || councilTorsDelegatedToUser?.length) ??
-    0 > 0
+    (communityTorsDelegatedToUser?.length ?? 0) > 0 ||
+    (councilTorsDelegatedToUser?.length ?? 0) > 0
+
+  console.log('has', hasDelegators)
 
   if (!walletId || !hasDelegators) {
     return null

--- a/components/TokenBalance/DelegateTokenBalanceCard.tsx
+++ b/components/TokenBalance/DelegateTokenBalanceCard.tsx
@@ -63,13 +63,9 @@ const DelegateBalanceCard = () => {
     )
   }
 
-  console.log('councilTorsDelegatedToUser', councilTorsDelegatedToUser)
-
   const hasDelegators =
     (communityTorsDelegatedToUser?.length ?? 0) > 0 ||
     (councilTorsDelegatedToUser?.length ?? 0) > 0
-
-  console.log('has', hasDelegators)
 
   if (!walletId || !hasDelegators) {
     return null

--- a/components/TreasuryAccount/AccountHeader.tsx
+++ b/components/TreasuryAccount/AccountHeader.tsx
@@ -4,14 +4,29 @@ import { getMintDecimalAmountFromNatural } from '@tools/sdk/units'
 import BigNumber from 'bignumber.js'
 import useTreasuryAccountStore from 'stores/useTreasuryAccountStore'
 import BaseAccountHeader from './BaseAccountHeader'
+import { useRealmDigitalAssetsQuery } from '@hooks/queries/digitalAssets'
+import { useMemo } from 'react'
 
 const AccountHeader = () => {
   const currentAccount = useTreasuryAccountStore((s) => s.currentAccount)
-  const nftsPerPubkey = useTreasuryAccountStore((s) => s.governanceNfts)
-  const nftsCount =
-    currentAccount?.governance && currentAccount.isNft
-      ? nftsPerPubkey[currentAccount?.governance?.pubkey.toBase58()]?.length
-      : 0
+  const { data: nfts } = useRealmDigitalAssetsQuery()
+  const nftsCount = useMemo(
+    () =>
+      nfts
+        ?.flat()
+        .filter(
+          (x) =>
+            x.ownership.owner ===
+              currentAccount?.governance.pubkey.toString() ||
+            x.ownership.owner ===
+              currentAccount?.extensions.transferAddress?.toString()
+        ).length ?? 0,
+    [
+      currentAccount?.extensions.transferAddress,
+      currentAccount?.governance.pubkey,
+      nfts,
+    ]
+  )
   const isNFT = currentAccount?.isNft
   const tokenInfo = useTreasuryAccountStore((s) => s.tokenInfo)
   const amount =

--- a/components/TreasuryAccount/DepositNFTFromWallet.tsx
+++ b/components/TreasuryAccount/DepositNFTFromWallet.tsx
@@ -1,11 +1,10 @@
-import { useEffect, useRef, useState } from 'react'
+import { useRef, useState } from 'react'
 import useTreasuryAccountStore from 'stores/useTreasuryAccountStore'
 import Button from '@components/Button'
 import Tooltip from '@components/Tooltip'
 import { NFTWithMint } from '@utils/uiTypes/nfts'
 import { PublicKey } from '@solana/web3.js'
 import NFTSelector, { NftSelectorFunctions } from '@components/NFTS/NFTSelector'
-import useGovernanceAssets from '@hooks/useGovernanceAssets'
 import NFTAccountSelect from './NFTAccountSelect'
 import useWalletOnePointOh from '@hooks/useWalletOnePointOh'
 import { notify } from '@utils/notifications'
@@ -20,6 +19,9 @@ import { SequenceType, sendTransactionsV3 } from '@utils/sendTransactions'
 import { getNativeTreasuryAddress } from '@solana/spl-governance'
 import useLegacyConnectionContext from '@hooks/useLegacyConnectionContext'
 import useGovernanceSelect from '@hooks/useGovernanceSelect'
+import queryClient from '@hooks/queries/queryClient'
+import { digitalAssetsQueryKeys } from '@hooks/queries/digitalAssets'
+import useSelectedRealmPubkey from '@hooks/selectedRealm/useSelectedRealmPubkey'
 
 const useMetaplexDeposit = () => {
   const wallet = useWalletOnePointOh()
@@ -62,14 +64,12 @@ const DepositNFTFromWallet = ({ additionalBtns }: { additionalBtns?: any }) => {
   const nftSelectorRef = useRef<NftSelectorFunctions>(null)
   const { setCurrentAccount } = useTreasuryAccountStore()
   const currentAccount = useTreasuryAccountStore((s) => s.currentAccount)
-  const { getNfts } = useTreasuryAccountStore()
   const [selectedNfts, setSelectedNfts] = useState<NFTWithMint[]>([])
   const wallet = useWalletOnePointOh()
   const connected = !!wallet?.connected
   const connection = useLegacyConnectionContext()
   const [isLoading, setIsLoading] = useState(false)
-  const [sendingSuccess, setSendingSuccess] = useState(false)
-  const { nftsGovernedTokenAccounts } = useGovernanceAssets()
+  const realmPk = useSelectedRealmPubkey()
 
   const deposit = useMetaplexDeposit()
 
@@ -83,7 +83,6 @@ const DepositNFTFromWallet = ({ additionalBtns }: { additionalBtns?: any }) => {
 
     for (const nft of selectedNfts) {
       setIsLoading(true)
-      setSendingSuccess(false)
 
       const owner = currentAccount.isSol
         ? currentAccount.extensions.transferAddress!
@@ -111,7 +110,16 @@ const DepositNFTFromWallet = ({ additionalBtns }: { additionalBtns?: any }) => {
       }
 
       await deposit(new PublicKey(nft.mintAddress))
-        .then(() => setSendingSuccess(true))
+        .then(() => {
+          setCurrentAccount(currentAccount!, connection)
+          realmPk &&
+            queryClient.invalidateQueries(
+              digitalAssetsQueryKeys.byRealm(
+                connection.current.rpcEndpoint,
+                realmPk
+              )
+            )
+        })
         .catch((e) => {
           notify({
             type: 'error',
@@ -123,17 +131,9 @@ const DepositNFTFromWallet = ({ additionalBtns }: { additionalBtns?: any }) => {
       setIsLoading(false)
     }
 
+    // high odds this does nothing at all
     nftSelectorRef.current?.handleGetNfts()
-    // @asktree: as far as I can tell this doesn't have the effect of refreshing any queries properly
-    getNfts(nftsGovernedTokenAccounts, connection)
   }
-
-  useEffect(() => {
-    if (sendingSuccess) {
-      setCurrentAccount(currentAccount!, connection)
-    }
-    // eslint-disable-next-line react-hooks/exhaustive-deps -- TODO please fix, it can cause difficult bugs. You might wanna check out https://bobbyhadz.com/blog/react-hooks-exhaustive-deps for info. -@asktree
-  }, [connected, sendingSuccess])
 
   const walletPk = wallet?.publicKey
 

--- a/components/instructions/TransactionInstructionCard.tsx
+++ b/components/instructions/TransactionInstructionCard.tsx
@@ -9,12 +9,15 @@ import {
   getInstructionDescriptor,
 } from './tools'
 import useGovernanceAssets from '@hooks/useGovernanceAssets'
-import axios from 'axios'
 import tokenPriceService from '@utils/services/tokenPrice'
-import { fetchNFTbyMint } from '@hooks/queries/nft'
 import { fetchTokenAccountByPubkey } from '@hooks/queries/tokenAccount'
 import useLegacyConnectionContext from '@hooks/useLegacyConnectionContext'
 import { useRealmQuery } from '@hooks/queries/realm'
+import queryClient from '@hooks/queries/queryClient'
+import {
+  dasByIdQueryFn,
+  digitalAssetsQueryKeys,
+} from '@hooks/queries/digitalAssets'
 
 const TransactionInstructionCard = ({
   instructionData,
@@ -25,10 +28,7 @@ const TransactionInstructionCard = ({
 }) => {
   const connection = useLegacyConnectionContext()
   const realm = useRealmQuery().data?.result
-  const {
-    nftsGovernedTokenAccounts,
-    governedTokenAccountsWithoutNfts,
-  } = useGovernanceAssets()
+  const { governedTokenAccountsWithoutNfts } = useGovernanceAssets()
 
   const [descriptor, setDescriptor] = useState<InstructionDescriptor>()
   const [nftImgUrl, setNftImgUrl] = useState('')
@@ -55,24 +55,19 @@ const TransactionInstructionCard = ({
     const isSol = governedTokenAccountsWithoutNfts.find(
       (x) => x.extensions.transferAddress?.toBase58() === sourcePk.toBase58()
     )?.isSol
-    const isNFTAccount = nftsGovernedTokenAccounts.find(
-      (x) =>
-        x.extensions.transferAddress?.toBase58() ===
-          tokenAccount?.owner.toBase58() ||
-        x.governance.pubkey.toBase58() === tokenAccount?.owner.toBase58()
-    )
 
-    if (isNFTAccount && mint) {
-      try {
-        const result = await fetchNFTbyMint(connection.current, mint)
-        if (result.found) {
-          const url = (await axios.get(result.result.uri)).data
-          setNftImgUrl(url.image)
-        }
-      } catch (e) {
-        console.log(e)
+    if (mint) {
+      const { result: nft } = await queryClient.fetchQuery({
+        queryKey: digitalAssetsQueryKeys.byId(
+          connection.current.rpcEndpoint,
+          mint
+        ),
+        queryFn: () => dasByIdQueryFn(connection.current, mint),
+        staleTime: Infinity,
+      })
+      if (nft !== undefined) {
+        setNftImgUrl(nft.content.files[0]?.cdn_uri ?? nft.content.files[0]?.uri)
       }
-      return
     }
 
     if (isSol) {
@@ -87,7 +82,7 @@ const TransactionInstructionCard = ({
       setTokenImgUrl(imgUrl)
     }
     return
-  }, [instructionData.accounts])
+  }, [connection, governedTokenAccountsWithoutNfts, instructionData.accounts])
 
   useEffect(() => {
     handleGetDescriptors()

--- a/components/treasuryV2/Details/NFTCollectionDetails/Header.tsx
+++ b/components/treasuryV2/Details/NFTCollectionDetails/Header.tsx
@@ -7,11 +7,9 @@ import { NFTCollection } from '@models/treasury/Asset'
 import { SecondaryButton } from '@components/Button'
 import Modal from '@components/Modal'
 import useGovernanceAssets from '@hooks/useGovernanceAssets'
-import useTreasuryAccountStore from 'stores/useTreasuryAccountStore'
 import Address from '@components/Address'
 
 import NFTCollectionPreviewIcon from '../../icons/NFTCollectionPreviewIcon'
-import useLegacyConnectionContext from '@hooks/useLegacyConnectionContext'
 import SendNft from '@components/SendNft'
 
 interface Props {
@@ -21,12 +19,7 @@ interface Props {
 
 export default function Header(props: Props) {
   const [sendNFTsModalOpen, setSendNFTsModalOpen] = useState(false)
-  const {
-    canUseTransferInstruction,
-    nftsGovernedTokenAccounts,
-  } = useGovernanceAssets()
-  const { setCurrentAccount } = useTreasuryAccountStore()
-  const connection = useLegacyConnectionContext()
+  const { canUseTransferInstruction } = useGovernanceAssets()
 
   const hasCount = !!props.nftCollection.totalCount
 
@@ -100,7 +93,7 @@ export default function Header(props: Props) {
               : undefined
           }
           onClick={() => {
-            setCurrentAccount(nftsGovernedTokenAccounts[0], connection) // this does nothing desireable ?
+            // setCurrentAccount(nftsGovernedTokenAccounts[0], connection) // @asktree: this does nothing identifiably desireable at all? there is no reason this value would correspond to anything the user is doing
             setSendNFTsModalOpen(true)
           }}
         >

--- a/components/treasuryV2/Details/WalletDetails/Header.tsx
+++ b/components/treasuryV2/Details/WalletDetails/Header.tsx
@@ -37,7 +37,7 @@ interface Props {
 export default function Header(props: Props) {
   const [openModal, setOpenModal] = useState<ModalType>(ModalType.None)
   const { fmtUrlWithCluster } = useQueryContext()
-  const { assetAccounts, nftsGovernedTokenAccounts } = useGovernanceAssets()
+  const { assetAccounts } = useGovernanceAssets()
   const { setCurrentAccount } = useTreasuryAccountStore()
   const { symbol } = useRealm()
   const connection = useLegacyConnectionContext()
@@ -94,6 +94,9 @@ export default function Header(props: Props) {
           onAddTokenAccount={() => setOpenModal(ModalType.NewTokenAccount)}
           onClose={() => setOpenModal(ModalType.None)}
           onDepositNFTsSelected={async () => {
+            // @asktree is really not sure whats going on here, but it should probably not exist anymore?
+            // we used to have a much weirder process for depositing nfts
+
             let account: AssetAccount | undefined
 
             for (const acc of assetAccounts) {
@@ -113,9 +116,9 @@ export default function Header(props: Props) {
 
             if (account) {
               setCurrentAccount(account, connection)
-            } else if (nftsGovernedTokenAccounts[0]) {
+            } /* else if (nftsGovernedTokenAccounts[0]) {
               setCurrentAccount(nftsGovernedTokenAccounts[0], connection)
-            }
+            } */
 
             setOpenModal(ModalType.DepositNFTs)
           }}

--- a/hooks/useGovernanceAssets.ts
+++ b/hooks/useGovernanceAssets.ts
@@ -120,11 +120,6 @@ export default function useGovernanceAssets() {
   const governedNativeAccounts = governedTokenAccounts.filter(
     (x) => x.type === AccountType.SOL
   )
-  const nftsGovernedTokenAccounts = governedTokenAccounts.filter(
-    (govTokenAcc) =>
-      govTokenAcc.type === AccountType.NFT ||
-      govTokenAcc.type === AccountType.SOL
-  )
   const canUseTokenTransferInstruction = governedTokenAccountsWithoutNfts.some(
     (acc) => {
       const governance = governancesArray.find(
@@ -879,42 +874,21 @@ export default function useGovernanceAssets() {
     )
   }
 
-  return useMemo(
-    () => ({
-      assetAccounts,
-      auxiliaryTokenAccounts,
-      availableInstructions,
-      availablePackages,
-      canMintRealmCouncilToken,
-      canUseAuthorityInstruction,
-      canUseMintInstruction,
-      canUseProgramUpgradeInstruction,
-      canUseTransferInstruction,
-      getPackageTypeById,
-      governancesArray,
-      governedNativeAccounts,
-      governedSPLTokenAccounts,
-      governedTokenAccounts,
-      governedTokenAccountsWithoutNfts,
-      nftsGovernedTokenAccounts,
-    }),
-    [
-      assetAccounts,
-      auxiliaryTokenAccounts,
-      availableInstructions,
-      availablePackages,
-      canMintRealmCouncilToken,
-      canUseAuthorityInstruction,
-      canUseMintInstruction,
-      canUseProgramUpgradeInstruction,
-      canUseTransferInstruction,
-      getPackageTypeById,
-      governancesArray,
-      governedNativeAccounts,
-      governedSPLTokenAccounts,
-      governedTokenAccounts,
-      governedTokenAccountsWithoutNfts,
-      nftsGovernedTokenAccounts,
-    ]
-  )
+  return {
+    assetAccounts,
+    auxiliaryTokenAccounts,
+    availableInstructions,
+    availablePackages,
+    canMintRealmCouncilToken,
+    canUseAuthorityInstruction,
+    canUseMintInstruction,
+    canUseProgramUpgradeInstruction,
+    canUseTransferInstruction,
+    getPackageTypeById,
+    governancesArray,
+    governedNativeAccounts,
+    governedSPLTokenAccounts,
+    governedTokenAccounts,
+    governedTokenAccountsWithoutNfts,
+  }
 }

--- a/pages/dao/[symbol]/gallery/index.tsx
+++ b/pages/dao/[symbol]/gallery/index.tsx
@@ -2,8 +2,6 @@ import { getExplorerUrl } from '@components/explorer/tools'
 import PreviousRouteBtn from '@components/PreviousRouteBtn'
 import { useMemo, useState } from 'react'
 import { PhotographIcon, PlusCircleIcon } from '@heroicons/react/outline'
-import useGovernanceAssets from '@hooks/useGovernanceAssets'
-import useTreasuryAccountStore from 'stores/useTreasuryAccountStore'
 import ImgWithLoader from '@components/ImgWithLoader'
 import Modal from '@components/Modal'
 import { LinkButton } from '@components/Button'
@@ -18,8 +16,6 @@ import DepositNFTFromWallet from '@components/TreasuryAccount/DepositNFTFromWall
 
 const Gallery = () => {
   const connection = useLegacyConnectionContext()
-  const { nftsGovernedTokenAccounts } = useGovernanceAssets()
-  const { setCurrentAccount } = useTreasuryAccountStore()
   const [openNftDepositModal, setOpenNftDepositModal] = useState(false)
   const [openSendNftsModal, setOpenSendNftsModal] = useState(false)
   const [
@@ -56,7 +52,6 @@ const Gallery = () => {
                 <LinkButton
                   onClick={() => {
                     setSelectedNftAndItsGovernance(undefined)
-                    setCurrentAccount(nftsGovernedTokenAccounts[0], connection)
                     setOpenSendNftsModal(true)
                   }}
                   className="flex items-center text-primary-light whitespace-nowrap mr-3"
@@ -66,7 +61,6 @@ const Gallery = () => {
                 </LinkButton>
                 <LinkButton
                   onClick={() => {
-                    setCurrentAccount(nftsGovernedTokenAccounts[0], connection)
                     setOpenNftDepositModal(true)
                   }}
                   className="flex items-center text-primary-light whitespace-nowrap"

--- a/stores/useTreasuryAccountStore.tsx
+++ b/stores/useTreasuryAccountStore.tsx
@@ -1,14 +1,11 @@
 import create, { State } from 'zustand'
-import { getNfts } from '@utils/tokens'
 import tokenPriceService, {
   TokenInfoWithoutDecimals,
 } from '@utils/services/tokenPrice'
-import { ConfirmedSignatureInfo, PublicKey } from '@solana/web3.js'
+import { ConfirmedSignatureInfo } from '@solana/web3.js'
 import { notify } from '@utils/notifications'
-import { NFTWithMint } from '@utils/uiTypes/nfts'
 import { WSOL_MINT } from '@components/instructions/tools'
 import { AccountType, AssetAccount } from '@utils/uiTypes/assets'
-import { ConnectionContext } from '@utils/connection'
 
 interface TreasuryAccountStore extends State {
   currentAccount: AssetAccount | null
@@ -16,19 +13,10 @@ interface TreasuryAccountStore extends State {
   tokenInfo?: TokenInfoWithoutDecimals
   recentActivity: ConfirmedSignatureInfo[]
 
-  allNfts: NFTWithMint[]
-  governanceNfts: {
-    [governance: string]: NFTWithMint[]
-  }
-  isLoadingNfts: boolean
   isLoadingRecentActivity: boolean
   isLoadingTokenAccounts: boolean
   setCurrentAccount: (account: AssetAccount, connection) => void
   handleFetchRecentActivity: (account: AssetAccount, connection) => void
-  getNfts: (
-    nftsGovernedTokenAccounts: AssetAccount[],
-    connection: ConnectionContext
-  ) => void
 }
 
 const useTreasuryAccountStore = create<TreasuryAccountStore>((set, _get) => ({
@@ -36,57 +24,9 @@ const useTreasuryAccountStore = create<TreasuryAccountStore>((set, _get) => ({
   mintAddress: '',
   tokenInfo: undefined,
   recentActivity: [],
-  allNfts: [],
-  governanceNfts: {},
-  isLoadingNfts: false,
   isLoadingRecentActivity: false,
   isLoadingTokenAccounts: false,
-  getNfts: async (nftsGovernedTokenAccounts, connection) => {
-    set((s) => {
-      s.isLoadingNfts = true
-    })
-    let realmNfts: NFTWithMint[] = []
-    const nftsPerPubkey = {}
-    for (const acc of nftsGovernedTokenAccounts) {
-      const governance = acc.governance.pubkey.toBase58()
-      try {
-        const nfts = acc.governance.pubkey
-          ? await getNfts(acc.governance.pubkey, connection)
-          : []
-        if (acc.isSol) {
-          const solAccountNfts = acc.extensions.transferAddress
-            ? await getNfts(
-                new PublicKey(acc.extensions.transferAddress!),
-                connection
-              )
-            : []
-          realmNfts = [...realmNfts, ...solAccountNfts]
 
-          nftsPerPubkey[acc.extensions.transferAddress!.toBase58()] = [
-            ...solAccountNfts,
-          ]
-        }
-        realmNfts = [...realmNfts, ...nfts]
-        if (governance) {
-          if (nftsPerPubkey[governance]) {
-            nftsPerPubkey[governance] = [...nftsPerPubkey[governance], ...nfts]
-          } else {
-            nftsPerPubkey[governance] = [...nfts]
-          }
-        }
-      } catch (e) {
-        console.log(e)
-        notify({
-          message: `Unable to fetch nfts for governance ${governance}`,
-        })
-      }
-    }
-    set((s) => {
-      s.allNfts = realmNfts
-      s.governanceNfts = nftsPerPubkey
-      s.isLoadingNfts = false
-    })
-  },
   setCurrentAccount: async (account, connection) => {
     if (!account) {
       set((s) => {


### PR DESCRIPTION
what I did not realize is that we have, in parallel, a completely separate nft querying setup in useTreasuryInfo (which, incidentally, is broken and for some reason counts all of monkedao's monkes 20 times). So idk what to make of that.