### PR TITLE
Remove toNumber() conversion in VSR

### DIFF
--- a/VoteStakeRegistry/components/TokenBalance/LockPluginTokenBalanceCard.tsx
+++ b/VoteStakeRegistry/components/TokenBalance/LockPluginTokenBalanceCard.tsx
@@ -246,7 +246,7 @@ const TokenDepositLock = ({
           />
         </div>
       ) : null}
-      {votingPower.toNumber() > 0 && (
+      {!votingPower.isZero() && (
         <div className="flex space-x-4 items-center mt-4">
           <VotingPowerBox
             votingPower={votingPower}


### PR DESCRIPTION
There is a `toNumber()` conversion in a VSR component that causes the app to crash with large vote weights. Since this conversion is just used to check whether the vote weight is greater than zero, I have replaced this code with an `isZero()` check instead.