### PR TITLE
fix createLUTProposal tx size

### DIFF
--- a/actions/createLUTproposal.ts
+++ b/actions/createLUTproposal.ts
@@ -123,8 +123,7 @@ export const createLUTProposal = async (
     .map((x) => x.chunkBy!)
 
   const lowestChunkBy = chunkBys.length ? Math.min(...chunkBys) : 2
-  console.log(instructionsData)
-  console.log('lowestChunkBy', lowestChunkBy)
+
   for (const [index, instruction] of instructionsData
     .filter((x) => x.data)
     .entries()) {

--- a/actions/createLUTproposal.ts
+++ b/actions/createLUTproposal.ts
@@ -262,7 +262,7 @@ export const createLUTProposal = async (
       ...extendInstructions.map((x) => {
         return {
           instructionsSet: [{ transactionInstruction: x }],
-          sequenceType: SequenceType.Parallel,
+          sequenceType: SequenceType.Sequential,
         }
       }),
     ],


### PR DESCRIPTION
While extending lookup table, the max address to add at once]e is ~20 addresses. 
reference from [here](https://docs.solana.com/developing/lookup-tables#:~:text=NOTE%3A%20Due%20to,transaction%27s%20memory%20limits).

Since sending cNFT can easily exceed that amount due to the proof and other instruction accounts, splitting `extendInstruction` into multiple transactions is necessary. Moreover, maybe `createLookupTable` and `extendLookupTable` should also separate into different transactions or the tx size will be larger than the restriction?

