### PR TITLE
emergency patch: stop using modified mangolana due to unsolved bug affecting HNT dao

### DIFF
--- a/utils/sendTransactions.tsx
+++ b/utils/sendTransactions.tsx
@@ -9,9 +9,9 @@ import {
 
 import { invalidateInstructionAccounts } from '@hooks/queries/queryClient'
 import {
-  sendSignAndConfirmTransactions,
   sendSignAndConfirmTransactionsProps,
-} from './modifiedMangolana'
+  sendSignAndConfirmTransactions,
+} from '@blockworks-foundation/mangolana/lib/transactions'
 
 export type WalletSigner = Pick<
   SignerWalletAdapter,
@@ -39,8 +39,9 @@ export const sendTransactionsV3 = ({
   timeoutStrategy,
   callbacks,
   config,
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   lookupTableAccounts,
-}: sendSignAndConfirmTransactionsProps) => {
+}: sendSignAndConfirmTransactionsProps & { lookupTableAccounts: any }) => {
   const callbacksWithUiComponent = {
     afterBatchSign: (signedTxnsCount) => {
       if (callbacks?.afterBatchSign) {
@@ -107,7 +108,7 @@ export const sendTransactionsV3 = ({
     callbacks: callbacksWithUiComponent,
     config: cfg,
     confirmLevel: 'confirmed', //TODO base this on connection confirmation level
-    lookupTableAccounts,
+    //lookupTableAccounts,
   })
 }
 


### PR DESCRIPTION
this will break cnft transfers which require LUTs