### PR TITLE
disable serum's work for showing other dao's TORs in treasury

### DIFF
--- a/components/treasuryV2/WalletList/WalletListItem/AssetList/TokenOwnerRecordListItem.tsx
+++ b/components/treasuryV2/WalletList/WalletListItem/AssetList/TokenOwnerRecordListItem.tsx
@@ -10,6 +10,14 @@ interface Props {
   pubkey: PublicKey
   governance: PublicKey
 }
+
+/**
+ * CURRENTLY NOT USED
+ * This was from work by Serum for intra-dao voting. As of Sep 29, 2023, it has no known users.
+ * In my (Agrippa's) opinion, a treasury-based flow for intra-dao voting is inferior to a generic
+ * wallet extension for the browser for building proposals using the same UI that normal users use to interact.
+ * (In the vein of Cordelia or Fuze wallet, or whatever the Squads thing is called)
+ */
 export default function TokenOwnerRecordListItem({
   pubkey,
   governance,

--- a/components/treasuryV2/WalletList/WalletListItem/AssetList/TokenOwnerRecordsList.tsx
+++ b/components/treasuryV2/WalletList/WalletListItem/AssetList/TokenOwnerRecordsList.tsx
@@ -15,6 +15,14 @@ interface Props {
   onToggleExpand?(): void
   governance: PublicKey
 }
+
+/**
+ * CURRENTLY NOT USED
+ * This was from work by Serum for intra-dao voting. As of Sep 29, 2023, it has no known users.
+ * In my (Agrippa's) opinion, a treasury-based flow for intra-dao voting is inferior to a generic
+ * wallet extension for the browser for building proposals using the same UI that normal users use to interact.
+ * (In the vein of Cordelia or Fuze wallet, or whatever the Squads thing is called)
+ */
 export default function TokenOwnerRecordsList({ governance, ...props }: Props) {
   const { connection } = useConnection()
 

--- a/components/treasuryV2/WalletList/WalletListItem/AssetList/index.tsx
+++ b/components/treasuryV2/WalletList/WalletListItem/AssetList/index.tsx
@@ -30,7 +30,6 @@ import {
 } from '../typeGuards'
 
 import { PublicKey } from '@solana/web3.js'
-import TokenOwnerRecordsList from './TokenOwnerRecordsList'
 import { GoverningTokenType } from '@solana/spl-governance'
 import TokenIcon from '@components/treasuryV2/icons/TokenIcon'
 import { useTokensMetadata } from '@hooks/queries/tokenMetadata'
@@ -242,14 +241,6 @@ export default function AssetList(props: Props) {
           onSelect={props.onSelectAsset}
           onToggleExpand={() => props.onToggleExpandSection?.('others')}
           itemsToHide={itemsToHide}
-        />
-      )}
-      {props.governance !== undefined && (
-        <TokenOwnerRecordsList
-          governance={props.governance}
-          disableCollapse={false}
-          expanded={true}
-          onToggleExpand={() => props.onToggleExpandSection?.('others')}
         />
       )}
     </div>

--- a/hooks/queries/tokenOwnerRecord.ts
+++ b/hooks/queries/tokenOwnerRecord.ts
@@ -60,6 +60,9 @@ const fetchTokenOwnerRecordsByRealmByOwner = async (
     },
   })
 
+/**
+ * CURRENTLY USED ONLY BY DISABLED COMPONENTS
+ */
 export const fetchTokenOwnerRecordsByOwnerAnyRealm = async (
   connection: Connection,
   ownerPk: PublicKey


### PR DESCRIPTION
This was from work by Serum for intra-dao voting. As of Sep 29, 2023, it has no known users.
In my opinion, a treasury-based flow for intra-dao voting is inferior to a generic wallet extension for the browser for building proposals using the same UI that normal users use to interact. (In the vein of Cordelia or Fuze wallet, or whatever the Squads thing is called)