### PR TITLE
Show default favicon if dao doesnt have a custom favicon

### DIFF
--- a/components/App.tsx
+++ b/components/App.tsx
@@ -125,12 +125,15 @@ export function AppContents(props: Props) {
   // Note: ?v==${Date.now()} is added to the url to force favicon refresh.
   // Without it browsers would cache the last used and won't change it for different realms
   // https://stackoverflow.com/questions/2208933/how-do-i-force-a-favicon-refresh
-  const faviconUrl =
-    symbol &&
-    tryParsePublicKey(symbol as string) === undefined && // don't try to use a custom favicon if this is a pubkey-based url
-    `/realms/${getResourcePathPart(
-      symbol as string
-    )}/favicon.ico?v=${Date.now()}`
+  const faviconUrl = useMemo(
+    () =>
+      symbol &&
+      tryParsePublicKey(symbol as string) === undefined && // don't try to use a custom favicon if this is a pubkey-based url
+      `/realms/${getResourcePathPart(
+        symbol as string
+      )}/favicon.ico?v=${Date.now()}`,
+    [symbol]
+  )
 
   // check if a file actually exists at faviconUrl
   const { result: faviconExists } = useAsync(

--- a/components/App.tsx
+++ b/components/App.tsx
@@ -37,6 +37,7 @@ import {
 } from '@sqds/iframe-adapter'
 import { WALLET_PROVIDERS } from '@utils/wallet-adapters'
 import { tryParsePublicKey } from '@tools/core/pubkey'
+import { useAsync } from 'react-async-hook'
 
 const Notifications = dynamic(() => import('../components/Notification'), {
   ssr: false,
@@ -131,6 +132,17 @@ export function AppContents(props: Props) {
       symbol as string
     )}/favicon.ico?v=${Date.now()}`
 
+  // check if a file actually exists at faviconUrl
+  const { result: faviconExists } = useAsync(
+    async () =>
+      faviconUrl
+        ? fetch(faviconUrl)
+            .then((response) => response.status === 200)
+            .catch(() => false)
+        : false,
+    [faviconUrl]
+  )
+
   useEffect(() => {
     if (
       realm &&
@@ -178,7 +190,7 @@ export function AppContents(props: Props) {
             background-color: #17161c;
           }
         `}</style>
-        {faviconUrl ? (
+        {faviconUrl && faviconExists ? (
           <>
             <link rel="icon" href={faviconUrl} />
           </>


### PR DESCRIPTION
Previously we would try to use a favicon for a dao, even if they didnt have one, resulting in a missing favicon and a 404 in the console.

Now, we check if it exists first. You might think NextJs has a way to do this without doing a fetch, but it doesn't seem to https://github.com/vercel/next.js/issues/10172