### PR TITLE
EditWalletRules: Integer quorum percent

### DIFF
--- a/hub/components/EditWalletRules/Form/index.tsx
+++ b/hub/components/EditWalletRules/Form/index.tsx
@@ -29,7 +29,6 @@ interface Props
 }
 
 function Form(props: Props & { title: string; description: string }) {
-  console.log('form props', props);
   const [showCouncilOptions, setShowCouncilOptions] = useState(
     props.initialCouncilRules?.canVote || false,
   );

--- a/hub/components/EditWalletRules/RulesDetailsInputs.tsx
+++ b/hub/components/EditWalletRules/RulesDetailsInputs.tsx
@@ -239,6 +239,7 @@ export function QuorumPercent(props: Props) {
             props.onRulesChange?.(newRules);
           }}
           onRenderValue={(val) => `${val}%`}
+          step={1}
         />
       </div>
     </ValueBlock>

--- a/hub/components/EditWalletRules/RulesDetailsInputs.tsx
+++ b/hub/components/EditWalletRules/RulesDetailsInputs.tsx
@@ -216,7 +216,7 @@ export function QuorumPercent(props: Props) {
     >
       <div className="grid grid-cols-[100px,1fr] gap-x-2 items-center">
         <SliderValue
-          min={0.01}
+          min={1}
           max={100}
           value={props.rules.quorumPercent}
           units="%"

--- a/hub/components/EditWalletRules/RulesDetailsInputs.tsx
+++ b/hub/components/EditWalletRules/RulesDetailsInputs.tsx
@@ -226,6 +226,7 @@ export function QuorumPercent(props: Props) {
             });
             props.onRulesChange?.(newRules);
           }}
+          integer
         />
         <Slider
           min={1}

--- a/hub/components/EditWalletRules/RulesDetailsInputs.tsx
+++ b/hub/components/EditWalletRules/RulesDetailsInputs.tsx
@@ -216,7 +216,7 @@ export function QuorumPercent(props: Props) {
     >
       <div className="grid grid-cols-[100px,1fr] gap-x-2 items-center">
         <SliderValue
-          min={1}
+          min={0.01}
           max={100}
           value={props.rules.quorumPercent}
           units="%"

--- a/hub/components/EditWalletRules/SliderValue/index.tsx
+++ b/hub/components/EditWalletRules/SliderValue/index.tsx
@@ -10,6 +10,7 @@ interface Props {
   value: number;
   units: React.ReactNode;
   onChange?(value: number): void;
+  integer?: boolean;
 }
 
 export function SliderValue(props: Props) {
@@ -32,7 +33,9 @@ export function SliderValue(props: Props) {
             /.*?(([0-9]*\.)?[0-9]+).*/g,
             '$1',
           );
-          const parsed = Math.floor(parseFloat(text));
+          const parsed = props.integer
+            ? Math.floor(parseFloat(text))
+            : parseFloat(text);
           const value = Number.isNaN(parsed) ? props.min : parsed;
           const newValue = Math.max(props.min, value);
           setValue(String(props.value)); // this is to force the input to update to the correct value

--- a/hub/components/EditWalletRules/SliderValue/index.tsx
+++ b/hub/components/EditWalletRules/SliderValue/index.tsx
@@ -34,7 +34,10 @@ export function SliderValue(props: Props) {
           );
           const parsed = parseFloat(text);
           const value = Number.isNaN(parsed) ? props.min : parsed;
-          props.onChange?.(Math.max(props.min, value));
+          const newValue = Math.max(props.min, value);
+          setValue(String(props.value)); // this is to force the input to update to the correct value
+          // even if the user enters an invalid value that doesnt actually change props.value
+          props.onChange?.(newValue);
         }}
       />
       <div

--- a/hub/components/EditWalletRules/SliderValue/index.tsx
+++ b/hub/components/EditWalletRules/SliderValue/index.tsx
@@ -32,7 +32,7 @@ export function SliderValue(props: Props) {
             /.*?(([0-9]*\.)?[0-9]+).*/g,
             '$1',
           );
-          const parsed = parseFloat(text);
+          const parsed = Math.floor(parseFloat(text));
           const value = Number.isNaN(parsed) ? props.min : parsed;
           const newValue = Math.max(props.min, value);
           setValue(String(props.value)); // this is to force the input to update to the correct value


### PR DESCRIPTION
Quorum percent can only be an integer between 1 and 100%, so this PR updates the wallet rules form to reflect this.