### PR TITLE
Pre-populating the Deposit Max Amount

### DIFF
--- a/components/DepositTokensButton.tsx
+++ b/components/DepositTokensButton.tsx
@@ -89,7 +89,7 @@ export const DepositTokensButton = ({
                 await deposit(nativeAmount)
                 setOpenModal(false)
               }}
-              disabled={(humanReadableMax && parseInt(amount) > humanReadableMax)}
+              disabled={humanReadableMax !== undefined && parseInt(amount) > humanReadableMax}
             >
               Confirm
             </Button>

--- a/components/DepositTokensButton.tsx
+++ b/components/DepositTokensButton.tsx
@@ -70,7 +70,7 @@ export const DepositTokensButton = ({
               Amount to deposit
               <span>
                 &nbsp;-&nbsp;<a href="#" onClick={() => { setAmount(humanReadableMax ? humanReadableMax.toString() : '') }}>Max</a>
-              </span>)
+              </span>
             </label>
             <Input
               placeholder={humanReadableMax?.toString() + ' (max)'}
@@ -88,7 +88,7 @@ export const DepositTokensButton = ({
                 await deposit(nativeAmount)
                 setOpenModal(false)
               }}
-              disabled={humanReadableMax !== undefined && parseInt(amount) > humanReadableMax}
+              disabled={humanReadableMax !== undefined && parseInt(amount) > humanReadableMax && parseInt(amount) > 0}
             >
               Confirm
             </Button>

--- a/components/DepositTokensButton.tsx
+++ b/components/DepositTokensButton.tsx
@@ -89,7 +89,7 @@ export const DepositTokensButton = ({
                 await deposit(nativeAmount)
                 setOpenModal(false)
               }}
-              disabled={parseInt(amount) > humanReadableMax}
+              disabled={(humanReadableMax && parseInt(amount) > humanReadableMax)}
             >
               Confirm
             </Button>

--- a/components/DepositTokensButton.tsx
+++ b/components/DepositTokensButton.tsx
@@ -43,7 +43,7 @@ export const DepositTokensButton = ({
       ? undefined
       : depositAmount.shiftedBy(-mintInfo.decimals).toNumber()
 
-  const [amount, setAmount] = useState(humanReadableMax?.toString() ?? '')
+  const [amount, setAmount] = useState((humanReadableMax?.toString() && humanReadableMax > 0) ? humanReadableMax.toString() : '')
 
   const deposit = useDepositCallback(role)
   return (

--- a/components/DepositTokensButton.tsx
+++ b/components/DepositTokensButton.tsx
@@ -60,10 +60,12 @@ export const DepositTokensButton = ({
         <Modal isOpen={openModal} onClose={() => setOpenModal(false)}>
           <div className="flex flex-col gap-y-4">
             <h2>Deposit tokens</h2>
+            <label>
+              Amount to deposit - <a href="#" onClick={() => { setAmount(humanReadableMax ? humanReadableMax.toString() : '') }}>Max</a>
+            </label>
             <Input
               placeholder={humanReadableMax?.toString() + ' (max)'}
               type="number"
-              label={<>Amount to deposit - <a href="#" onClick={() => { setAmount(humanReadableMax ? humanReadableMax.toString() : '') }}>Max</a></>}
               value={amount}
               onChange={(e) => { setAmount(e.target.value) }}
               max={humanReadableMax}

--- a/components/DepositTokensButton.tsx
+++ b/components/DepositTokensButton.tsx
@@ -68,10 +68,9 @@ export const DepositTokensButton = ({
             <h2>Deposit tokens</h2>
             <label>
               Amount to deposit
-              {amount && humanReadableMax && parseInt(amount) < humanReadableMax && (
-                <span>
-                  &nbsp;-&nbsp;<a href="#" onClick={() => { setAmount(humanReadableMax ? humanReadableMax.toString() : '') }}>Max</a>
-                </span>)}
+              <span>
+                &nbsp;-&nbsp;<a href="#" onClick={() => { setAmount(humanReadableMax ? humanReadableMax.toString() : '') }}>Max</a>
+              </span>)
             </label>
             <Input
               placeholder={humanReadableMax?.toString() + ' (max)'}

--- a/components/DepositTokensButton.tsx
+++ b/components/DepositTokensButton.tsx
@@ -30,12 +30,11 @@ export const DepositTokensButton = ({
   const depositTooltipContent = !connected
     ? 'Connect your wallet to deposit'
     : !hasTokensInWallet
-    ? "You don't have any governance tokens in your wallet to deposit."
-    : undefined
+      ? "You don't have any governance tokens in your wallet to deposit."
+      : undefined
 
   const ButtonToUse = as === 'primary' ? Button : SecondaryButton
   const [openModal, setOpenModal] = useState(false)
-  const [amount, setAmount] = useState('')
   const mint = useGoverningTokenMint(role)
   const mintInfo = useMintInfoByPubkeyQuery(mint).data?.result
 
@@ -43,6 +42,8 @@ export const DepositTokensButton = ({
     mintInfo === undefined
       ? undefined
       : depositAmount.shiftedBy(-mintInfo.decimals).toNumber()
+
+  const [amount, setAmount] = useState(humanReadableMax)
 
   const deposit = useDepositCallback(role)
   return (

--- a/components/DepositTokensButton.tsx
+++ b/components/DepositTokensButton.tsx
@@ -67,7 +67,11 @@ export const DepositTokensButton = ({
           <div className="flex flex-col gap-y-4">
             <h2>Deposit tokens</h2>
             <label>
-              Amount to deposit - <a href="#" onClick={() => { setAmount(humanReadableMax ? humanReadableMax.toString() : '') }}>Max</a>
+              Amount to deposit
+              {(!amount || amount.length < 0 || parseInt(amount) < humanReadableMax) &&
+                <>
+                  &nbsp;-&nbsp;<a href="#" onClick={() => { setAmount(humanReadableMax ? humanReadableMax.toString() : '') }}>Max</a>
+                </>}
             </label>
             <Input
               placeholder={humanReadableMax?.toString() + ' (max)'}
@@ -85,6 +89,7 @@ export const DepositTokensButton = ({
                 await deposit(nativeAmount)
                 setOpenModal(false)
               }}
+              disabled={parseInt(amount) > humanReadableMax}
             >
               Confirm
             </Button>

--- a/components/DepositTokensButton.tsx
+++ b/components/DepositTokensButton.tsx
@@ -65,10 +65,7 @@ export const DepositTokensButton = ({
               type="number"
               label="Amount to deposit"
               value={amount}
-              onChange={(e) => {
-                const inputValue = e.target.value;
-                setAmount(inputValue);
-              }}
+              onChange={(e) => { setAmount(e.target.value) }}
               max={humanReadableMax}
             />
             <Button

--- a/components/DepositTokensButton.tsx
+++ b/components/DepositTokensButton.tsx
@@ -43,7 +43,7 @@ export const DepositTokensButton = ({
       ? undefined
       : depositAmount.shiftedBy(-mintInfo.decimals).toNumber()
 
-  const [amount, setAmount] = useState((humanReadableMax?.toString() && humanReadableMax > 0) ? humanReadableMax.toString() : '')
+  const [amount, setAmount] = useState((humanReadableMax && humanReadableMax?.toString() && parseInt(humanReadableMax) > 0) ? humanReadableMax.toString() : '')
 
   const deposit = useDepositCallback(role)
   return (
@@ -63,7 +63,7 @@ export const DepositTokensButton = ({
             <Input
               placeholder={humanReadableMax?.toString() + ' (max)'}
               type="number"
-              label={<>Amount to deposit - <a href="#" onClick={() => { setAmount(humanReadableMax?.toString()) }}>Max</a></>}
+              label={<>Amount to deposit - <a href="#" onClick={() => { setAmount(humanReadableMax ? humanReadableMax.toString() || '') }}>Max</a></>}
               value={amount}
               onChange={(e) => { setAmount(e.target.value) }}
               max={humanReadableMax}

--- a/components/DepositTokensButton.tsx
+++ b/components/DepositTokensButton.tsx
@@ -43,7 +43,7 @@ export const DepositTokensButton = ({
       ? undefined
       : depositAmount.shiftedBy(-mintInfo.decimals).toNumber()
 
-  const [amount, setAmount] = useState((humanReadableMax && humanReadableMax?.toString() && parseInt(humanReadableMax) > 0) ? humanReadableMax.toString() : '')
+  const [amount, setAmount] = useState((humanReadableMax && humanReadableMax?.toString() && humanReadableMax > 0) ? humanReadableMax.toString() : '')
 
   const deposit = useDepositCallback(role)
   return (

--- a/components/DepositTokensButton.tsx
+++ b/components/DepositTokensButton.tsx
@@ -63,7 +63,7 @@ export const DepositTokensButton = ({
             <Input
               placeholder={humanReadableMax?.toString() + ' (max)'}
               type="number"
-              label="Amount to deposit"
+              label={<>Amount to deposit - <a href="#" onClick={(e) => { setAmount(humanReadableMax?.toString()) }}>Max</a></>}
               value={amount}
               onChange={(e) => { setAmount(e.target.value) }}
               max={humanReadableMax}

--- a/components/DepositTokensButton.tsx
+++ b/components/DepositTokensButton.tsx
@@ -68,10 +68,10 @@ export const DepositTokensButton = ({
             <h2>Deposit tokens</h2>
             <label>
               Amount to deposit
-              {(!amount || amount.length < 0 || (humanReadableMax && parseInt(amount) < humanReadableMax)) &&
-                <>
+              {amount && humanReadableMax && parseInt(amount) < humanReadableMax && (
+                <span>
                   &nbsp;-&nbsp;<a href="#" onClick={() => { setAmount(humanReadableMax ? humanReadableMax.toString() : '') }}>Max</a>
-                </>}
+                </span>)}
             </label>
             <Input
               placeholder={humanReadableMax?.toString() + ' (max)'}

--- a/components/DepositTokensButton.tsx
+++ b/components/DepositTokensButton.tsx
@@ -43,7 +43,7 @@ export const DepositTokensButton = ({
       ? undefined
       : depositAmount.shiftedBy(-mintInfo.decimals).toNumber()
 
-  const [amount, setAmount] = useState(humanReadableMax)
+  const [amount, setAmount] = useState(humanReadableMax.toString())
 
   const deposit = useDepositCallback(role)
   return (
@@ -67,13 +67,7 @@ export const DepositTokensButton = ({
               value={amount}
               onChange={(e) => {
                 const inputValue = e.target.value;
-                const parsedValue = parseFloat(inputValue); // or parseInt for integers
-
-                if (!isNaN(parsedValue)) {
-                  setAmount(parsedValue);
-                } else {
-                  setAmount(undefined);
-                }
+                setAmount(inputValue);
               }}
               max={humanReadableMax}
             />

--- a/components/DepositTokensButton.tsx
+++ b/components/DepositTokensButton.tsx
@@ -43,7 +43,7 @@ export const DepositTokensButton = ({
       ? undefined
       : depositAmount.shiftedBy(-mintInfo.decimals).toNumber()
 
-  const [amount, setAmount] = useState(humanReadableMax.toString())
+  const [amount, setAmount] = useState(humanReadableMax ? humanReadableMax.toString() : '')
 
   const deposit = useDepositCallback(role)
   return (

--- a/components/DepositTokensButton.tsx
+++ b/components/DepositTokensButton.tsx
@@ -65,7 +65,16 @@ export const DepositTokensButton = ({
               type="number"
               label="Amount to deposit"
               value={amount}
-              onChange={(e) => setAmount(e.target.value)}
+              onChange={(e) => {
+                const inputValue = e.target.value;
+                const parsedValue = parseFloat(inputValue); // or parseInt for integers
+
+                if (!isNaN(parsedValue)) {
+                  setAmount(parsedValue);
+                } else {
+                  setAmount(undefined);
+                }
+              }}
               max={humanReadableMax}
             />
             <Button

--- a/components/DepositTokensButton.tsx
+++ b/components/DepositTokensButton.tsx
@@ -63,7 +63,7 @@ export const DepositTokensButton = ({
             <Input
               placeholder={humanReadableMax?.toString() + ' (max)'}
               type="number"
-              label={<>Amount to deposit - <a href="#" onClick={(e) => { setAmount(humanReadableMax?.toString()) }}>Max</a></>}
+              label={<>Amount to deposit - <a href="#" onClick={() => { setAmount(humanReadableMax?.toString()) }}>Max</a></>}
               value={amount}
               onChange={(e) => { setAmount(e.target.value) }}
               max={humanReadableMax}

--- a/components/DepositTokensButton.tsx
+++ b/components/DepositTokensButton.tsx
@@ -88,7 +88,7 @@ export const DepositTokensButton = ({
                 await deposit(nativeAmount)
                 setOpenModal(false)
               }}
-              disabled={humanReadableMax !== undefined && parseInt(amount) > humanReadableMax && parseInt(amount) > 0}
+              disabled={humanReadableMax !== undefined && (parseInt(amount) > humanReadableMax || parseInt(amount) > 0)}
             >
               Confirm
             </Button>

--- a/components/DepositTokensButton.tsx
+++ b/components/DepositTokensButton.tsx
@@ -68,7 +68,7 @@ export const DepositTokensButton = ({
             <h2>Deposit tokens</h2>
             <label>
               Amount to deposit
-              {(!amount || amount.length < 0 || parseInt(amount) < humanReadableMax) &&
+              {(!amount || amount.length < 0 || (humanReadableMax && parseInt(amount) < humanReadableMax)) &&
                 <>
                   &nbsp;-&nbsp;<a href="#" onClick={() => { setAmount(humanReadableMax ? humanReadableMax.toString() : '') }}>Max</a>
                 </>}

--- a/components/DepositTokensButton.tsx
+++ b/components/DepositTokensButton.tsx
@@ -63,7 +63,7 @@ export const DepositTokensButton = ({
             <Input
               placeholder={humanReadableMax?.toString() + ' (max)'}
               type="number"
-              label={<>Amount to deposit - <a href="#" onClick={() => { setAmount(humanReadableMax ? humanReadableMax.toString() || '') }}>Max</a></>}
+              label={<>Amount to deposit - <a href="#" onClick={() => { setAmount(humanReadableMax ? humanReadableMax.toString() : '') }}>Max</a></>}
               value={amount}
               onChange={(e) => { setAmount(e.target.value) }}
               max={humanReadableMax}

--- a/components/DepositTokensButton.tsx
+++ b/components/DepositTokensButton.tsx
@@ -5,7 +5,7 @@ import useUserGovTokenAccountQuery from '@hooks/useUserGovTokenAccount'
 import { useDepositCallback } from './GovernancePower/Vanilla/useDepositCallback'
 import useWalletOnePointOh from '@hooks/useWalletOnePointOh'
 import Modal from './Modal'
-import { useState } from 'react'
+import { useState, useEffect } from 'react'
 import useGoverningTokenMint from '@hooks/selectedRealm/useGoverningTokenMint'
 import { useMintInfoByPubkeyQuery } from '@hooks/queries/mintInfo'
 import Input from './inputs/Input'
@@ -43,7 +43,12 @@ export const DepositTokensButton = ({
       ? undefined
       : depositAmount.shiftedBy(-mintInfo.decimals).toNumber()
 
-  const [amount, setAmount] = useState(humanReadableMax ? humanReadableMax?.toString() : '')
+  const [amount, setAmount] = useState('')
+
+  useEffect(() => {
+    if (humanReadableMax && humanReadableMax > 0)
+      setAmount(humanReadableMax ? humanReadableMax.toString() : '')
+  }, [humanReadableMax])
 
   const deposit = useDepositCallback(role)
 

--- a/components/DepositTokensButton.tsx
+++ b/components/DepositTokensButton.tsx
@@ -43,7 +43,7 @@ export const DepositTokensButton = ({
       ? undefined
       : depositAmount.shiftedBy(-mintInfo.decimals).toNumber()
 
-  const [amount, setAmount] = useState(humanReadableMax ? humanReadableMax.toString() : '')
+  const [amount, setAmount] = useState(humanReadableMax?.toString() ?? '')
 
   const deposit = useDepositCallback(role)
   return (

--- a/components/DepositTokensButton.tsx
+++ b/components/DepositTokensButton.tsx
@@ -43,9 +43,10 @@ export const DepositTokensButton = ({
       ? undefined
       : depositAmount.shiftedBy(-mintInfo.decimals).toNumber()
 
-  const [amount, setAmount] = useState((humanReadableMax && humanReadableMax?.toString() && humanReadableMax > 0) ? humanReadableMax.toString() : '')
+  const [amount, setAmount] = useState(humanReadableMax ? humanReadableMax?.toString() : '')
 
   const deposit = useDepositCallback(role)
+
   return (
     <>
       <ButtonToUse


### PR DESCRIPTION
The Deposit button automatically allowed the Max amount to be deposited, nevertheless this changed causing issues for our DAO members, in specific we identified the following:
- Deposit amount should be defaulted to the Max amount
- Deposit amount when typing is no longer available, so for larger numbers the total available, the user can enter an amount which is not their actual max amount.

To improve this slow and confusing experience, the popup should be easier to navigate as specified above.

We also recommend that in the future this button is pushed as an advanced button either in the "My Governance View" or as a dropdown button as an additional option

The fixes here will be to improve the UI/UX and allow a default Max to be set along with any helper buttons to ease setting the Max deposit amount