### PR TITLE
Correction in label 'Grant to:' for Grant proposal.

### DIFF
--- a/components/instructions/programs/voteStakeRegistry.tsx
+++ b/components/instructions/programs/voteStakeRegistry.tsx
@@ -284,7 +284,7 @@ const grantIx = (programId: PublicKey) => ({
           <>
             {decodedInstructionData ? (
               <div className="space-y-3">
-                <div>Grant to: {accounts[8].pubkey.toBase58()}</div>
+                <div>Grant to: {accounts[3].pubkey.toBase58()}</div>
                 <div>Lock type: {lockupKind}</div>
                 <div>
                   Amount:{' '}


### PR DESCRIPTION
Currently is used the accounts 9 which is payer.
It should be used account number 3 which is voter authority.

<img width="486" alt="image" src="https://github.com/solana-labs/governance-ui/assets/1104559/bb61e5f0-f432-4fa7-9c99-09d2996a5f3b">
