### PR TITLE
[bugfix] just use realm pks when talking to governance-api

### DIFF
--- a/hub/components/EditWalletRules/index.tsx
+++ b/hub/components/EditWalletRules/index.tsx
@@ -58,6 +58,7 @@ function stepName(step: Step): string {
 interface Props {
   className?: string;
   governanceAddress: PublicKey;
+  realmPk: PublicKey;
 }
 
 export function EditWalletRules(props: Props) {
@@ -71,7 +72,7 @@ export function EditWalletRules(props: Props) {
   const [result] = useQuery(gql.getGovernanceRulesResp, {
     query: gql.getGovernanceRules,
     variables: {
-      realmUrlId: symbol,
+      realmUrlId: realmPk,
       governancePublicKey: props.governanceAddress.toBase58(),
     },
   });

--- a/hub/components/EditWalletRules/index.tsx
+++ b/hub/components/EditWalletRules/index.tsx
@@ -72,7 +72,7 @@ export function EditWalletRules(props: Props) {
   const [result] = useQuery(gql.getGovernanceRulesResp, {
     query: gql.getGovernanceRules,
     variables: {
-      realmUrlId: realmPk,
+      realmUrlId: props.realmPk,
       governancePublicKey: props.governanceAddress.toBase58(),
     },
   });

--- a/pages/dao/[symbol]/editConfig.tsx
+++ b/pages/dao/[symbol]/editConfig.tsx
@@ -1,13 +1,12 @@
 import Head from 'next/head'
-import { useRouter } from 'next/router'
 
 import { GraphQLProvider } from '@hub/providers/GraphQL'
 import { JWTProvider } from '@hub/providers/JWT'
 import { EditRealmConfig } from '@hub/components/EditRealmConfig'
+import useSelectedRealmPubkey from '@hooks/selectedRealm/useSelectedRealmPubkey'
 
 export default function EditConfigPage() {
-  const router = useRouter()
-  const { symbol } = router.query
+  const realmPk = useSelectedRealmPubkey()
 
   return (
     <>
@@ -19,10 +18,12 @@ export default function EditConfigPage() {
             <meta property="og:title" content="Edit Org Config" key="title" />
           </Head>
           <div className="dark">
-            <EditRealmConfig
-              className="min-h-screen"
-              realmUrlId={symbol as string}
-            />
+            {realmPk && (
+              <EditRealmConfig
+                className="min-h-screen"
+                realmUrlId={realmPk.toString()}
+              />
+            )}
           </div>
         </GraphQLProvider>
       </JWTProvider>

--- a/pages/dao/[symbol]/treasury/governance/[governanceId]/edit.tsx
+++ b/pages/dao/[symbol]/treasury/governance/[governanceId]/edit.tsx
@@ -5,6 +5,7 @@ import { PublicKey } from '@solana/web3.js'
 import { EditWalletRules } from '@hub/components/EditWalletRules'
 import { GraphQLProvider } from '@hub/providers/GraphQL'
 import { JWTProvider } from '@hub/providers/JWT'
+import useSelectedRealmPubkey from '@hooks/selectedRealm/useSelectedRealmPubkey'
 
 export default function EditWallet() {
   const router = useRouter()
@@ -14,8 +15,11 @@ export default function EditWallet() {
   const governanceAddress =
     typeof governanceId === 'string' ? new PublicKey(governanceId) : undefined
 
+  const realmPk = useSelectedRealmPubkey()
+
   return (
-    governanceAddress && (
+    governanceAddress &&
+    realmPk && (
       <>
         <JWTProvider>
           <GraphQLProvider>
@@ -26,7 +30,10 @@ export default function EditWallet() {
             </Head>
             <div className="dark w-full max-w-3xl mx-auto">
               <div className="dark:bg-neutral-900 rounded px-4 lg:px-8">
-                <EditWalletRules governanceAddress={governanceAddress} />
+                <EditWalletRules
+                  governanceAddress={governanceAddress}
+                  realmPk={realmPk}
+                />
               </div>
             </div>
           </GraphQLProvider>


### PR DESCRIPTION
previously governance-api took a dao's symbol or pk when querying for information about it. but it doesnt seem to be up-to-date on the symbols of daos. there is no reason it cant just accept only PK, so I made the views that we use in realms use the PK.

fixes https://discord.com/channels/910194960941338677/1149290021996732477/threads/1173741934641152140