### PR TITLE
style dialect again

### DIFF
--- a/components/DialectNotificationsModal/index.tsx
+++ b/components/DialectNotificationsModal/index.tsx
@@ -34,7 +34,7 @@ const themeVariables: IncomingThemeVariables = {
       toggleBackgroundActive: 'bg-primary-light',
     },
     textStyles: {
-      input: 'text-black',
+      input: 'text-primary-1 bg-bkg-1 border-none hover:border-none',
     },
     outlinedInput: `${defaultVariables.dark.outlinedInput} focus-within:border-primary-light`,
     disabledButton: `${defaultVariables.dark.disabledButton} border-primary-light font-bold rounded-full border-fgd-3 text-fgd-3 cursor-not-allowed`,


### PR DESCRIPTION
there were some style collisions in the dialect form from my last attempt, reported here: https://discord.com/channels/910194960941338677/1174481804875534417/1175083032596721714

Now it looks like this.
<img width="478" alt="image" src="https://github.com/solana-labs/governance-ui/assets/12001874/03034c0a-2e72-4905-b2c7-85631355c6f9">
