### PR TITLE
Fix Civic functionality for DAO config UI

### DIFF
--- a/GatewayPlugin/config.ts
+++ b/GatewayPlugin/config.ts
@@ -1,0 +1,23 @@
+// A list of "passes" offered by Civic to verify or gate access to a DAO.
+export const availablePasses = [
+    {
+        name: 'Uniqueness',
+        value: 'uniqobk8oGh4XBLMqM68K8M2zNu3CdYX7q5go7whQiv',
+        description: 'A biometric proof of personhood, preventing Sybil attacks while retaining privacy'
+    },
+    {
+        name: 'ID Verification',
+        value: 'bni1ewus6aMxTxBi5SAfzEmmXLf8KcVFRmTfproJuKw',
+        description: 'A KYC process for your DAO, allowing users to prove their identity by presenting a government-issued ID'
+    },
+    {
+        name: 'Bot Resistance',
+        value: 'ignREusXmGrscGNUesoU9mxfds9AiYTezUKex2PsZV6',
+        description: 'A simple CAPTCHA to prevent bots from spamming your DAO'
+    },
+    {
+        name: 'Other',
+        value: '',
+        description: 'Set up your own custom verification (contact Civic.com for options)'
+    },
+] as const;

--- a/hub/components/EditRealmConfig/CommunityStructure/index.tsx
+++ b/hub/components/EditRealmConfig/CommunityStructure/index.tsx
@@ -25,11 +25,13 @@ interface Props
     nftCollection?: PublicKey;
     nftCollectionSize: number;
     nftCollectionWeight: BN;
+    civicPassType: Config['civicPassType'];
   }> {
   currentConfigAccount: Config['configAccount'];
   currentNftCollection?: PublicKey;
   currentNftCollectionSize: number;
   currentNftCollectionWeight: BN;
+  currentCivicPassType: Config['civicPassType'];
   communityMint: Config['communityMint'];
   className?: string;
 }
@@ -43,6 +45,7 @@ export function CommunityStructure(props: Props) {
     nftCollection: props.currentNftCollection,
     nftCollectionSize: props.currentNftCollectionSize,
     nftCollectionWeight: props.currentNftCollectionWeight,
+    civicPassType: props.currentCivicPassType,
   };
 
   const votingStructure = {
@@ -52,6 +55,7 @@ export function CommunityStructure(props: Props) {
     nftCollection: props.nftCollection,
     nftCollectionSize: props.nftCollectionSize,
     nftCollectionWeight: props.nftCollectionWeight,
+    civicPassType: props.civicPassType,
   };
 
   const minTokensToManage = new BigNumber(
@@ -211,6 +215,7 @@ export function CommunityStructure(props: Props) {
                 nftCollection,
                 nftCollectionSize,
                 nftCollectionWeight,
+                civicPassType,
               }) => {
                 const newConfig = produce(
                   { ...props.configAccount },
@@ -245,6 +250,13 @@ export function CommunityStructure(props: Props) {
                     !props.nftCollectionWeight.eq(nftCollectionWeight)
                   ) {
                     props.onNftCollectionWeightChange?.(nftCollectionWeight);
+                  }
+
+                  if (
+                    typeof civicPassType !== 'undefined' &&
+                    !props.civicPassType?.equals(civicPassType)
+                  ) {
+                    props.onCivicPassTypeChange?.(civicPassType);
                   }
                 }, 0);
               }}

--- a/hub/components/EditRealmConfig/Form/index.tsx
+++ b/hub/components/EditRealmConfig/Form/index.tsx
@@ -67,9 +67,11 @@ export function Form(props: Props) {
         currentNftCollection={props.currentConfig.nftCollection}
         currentNftCollectionSize={props.currentConfig.nftCollectionSize}
         currentNftCollectionWeight={props.currentConfig.nftCollectionWeight}
+        currentCivicPassType={props.currentConfig.civicPassType}
         nftCollection={props.config.nftCollection}
         nftCollectionSize={props.config.nftCollectionSize}
         nftCollectionWeight={props.config.nftCollectionWeight}
+        civicPassType={props.config.civicPassType}
         onConfigChange={(config) => {
           const newConfig = produce(props.config, (data) => {
             data.config = config;
@@ -101,6 +103,13 @@ export function Form(props: Props) {
         onNftCollectionWeightChange={(nftCollectionWeight) => {
           const newConfig = produce(props.config, (data) => {
             data.nftCollectionWeight = nftCollectionWeight;
+          });
+
+          props.onConfigChange?.(newConfig);
+        }}
+        onCivicPassTypeChange={(civicPassType) => {
+          const newConfig = produce(props.config, (data) => {
+            data.civicPassType = civicPassType;
           });
 
           props.onConfigChange?.(newConfig);

--- a/hub/components/EditRealmConfig/UpdatesList/index.tsx
+++ b/hub/components/EditRealmConfig/UpdatesList/index.tsx
@@ -10,6 +10,7 @@ import { PublicKey } from '@solana/web3.js';
 import { BigNumber } from 'bignumber.js';
 import BN from 'bn.js';
 
+import { availablePasses } from '../../../../GatewayPlugin/config';
 import { Config } from '../fetchConfig';
 import { getLabel } from '../TokenTypeSelector';
 import {
@@ -45,6 +46,7 @@ export function buildUpdates(config: Config) {
     nftCollection: config.nftCollection,
     nftCollectionSize: config.nftCollectionSize,
     nftCollectionWeight: config.nftCollectionWeight,
+    civicPassType: config.civicPassType,
   };
 }
 
@@ -80,6 +82,16 @@ export function diff<T extends { [key: string]: unknown }>(
 
   return diffs;
 }
+
+const civicPassTypeLabel = (civicPassType: PublicKey | undefined): string => {
+  if (!civicPassType) return 'None';
+  const foundPass = availablePasses.find(
+    (pass) => pass.value === civicPassType?.toBase58(),
+  );
+
+  if (!foundPass) return 'Other (' + abbreviateAddress(civicPassType) + ')';
+  return foundPass.name;
+};
 
 function votingStructureText(
   votingPluginDiff: [PublicKey | undefined, PublicKey | undefined],
@@ -156,7 +168,8 @@ export function UpdatesList(props: Props) {
     'communityMaxVotingPlugin' in updates ||
     'nftCollection' in updates ||
     'nftCollectionSize' in updates ||
-    'nftCollectionWeight' in updates;
+    'nftCollectionWeight' in updates ||
+    'civicPassType' in updates;
 
   const hasCouncilUpdates =
     'councilTokenType' in updates ||
@@ -415,6 +428,19 @@ export function UpdatesList(props: Props) {
                       {new BigNumber(updates.nftCollectionWeight[0].toString())
                         .shiftedBy(-props.config.communityMint.account.decimals)
                         .toFormat()}
+                    </div>
+                  </div>
+                }
+              />
+            )}
+            {'civicPassType' in updates && (
+              <SummaryItem
+                label="Civic Pass Type"
+                value={
+                  <div className="flex items-baseline">
+                    <div>{civicPassTypeLabel(updates.civicPassType[1])}</div>
+                    <div className="ml-3 text-base text-neutral-500 line-through">
+                      {civicPassTypeLabel(updates.civicPassType[0])}
                     </div>
                   </div>
                 }

--- a/hub/components/EditRealmConfig/VotingStructureSelector/CivicConfigurator.tsx
+++ b/hub/components/EditRealmConfig/VotingStructureSelector/CivicConfigurator.tsx
@@ -1,0 +1,219 @@
+import ChevronDownIcon from '@carbon/icons-react/lib/ChevronDown';
+import * as DropdownMenu from '@radix-ui/react-dropdown-menu';
+
+import { PublicKey } from '@solana/web3.js';
+import React, { FC, useRef, useState } from 'react';
+
+import { availablePasses } from '../../../../GatewayPlugin/config';
+import Input from '@components/inputs/Input';
+import cx from '@hub/lib/cx';
+
+const itemStyles = cx(
+  'border',
+  'cursor-pointer',
+  'gap-x-4',
+  'grid-cols-[150px,1fr,20px]',
+  'grid',
+  'h-14',
+  'items-center',
+  'px-4',
+  'w-full',
+  'rounded-md',
+  'text-left',
+  'transition-colors',
+  'dark:bg-neutral-800',
+  'dark:border-neutral-700',
+  'dark:hover:bg-neutral-700',
+);
+
+const labelStyles = cx('font-700', 'dark:text-neutral-50', 'w-full');
+const descriptionStyles = cx('dark:text-neutral-400 text-sm');
+const iconStyles = cx('fill-neutral-500', 'h-5', 'transition-transform', 'w-4');
+
+// Infer the types from the available passes, giving type safety on the `other` and `default` pass types
+type ArrayElement<
+  ArrayType extends readonly unknown[]
+> = ArrayType extends readonly (infer ElementType)[] ? ElementType : never;
+type CivicPass = ArrayElement<typeof availablePasses>;
+
+const isOther = (pass: CivicPass | undefined): boolean =>
+  pass?.name === 'Other';
+const other = availablePasses.find(isOther) as CivicPass;
+
+// if nothing is selected, Uniqueness is most likely what the user wants
+const defaultPass = availablePasses.find(
+  (pass) => pass.name === 'Uniqueness',
+) as CivicPass;
+
+// If Other is selected, allow the user to enter a custom pass address here.
+const ManualPassEntry: FC<{
+  manualPassType?: PublicKey;
+  onChange: (newManualPassType?: PublicKey) => void;
+}> = ({ manualPassType, onChange }) => {
+  const [error, setError] = useState<string>();
+  const [inputValue, setInputValue] = useState<string>(
+    manualPassType?.toBase58() || '',
+  );
+
+  return (
+    <div className="relative">
+      <div className="absolute top-0 left-2 w-0 h-12 border-l dark:border-neutral-700" />
+      <div className="pt-10 pl-8">
+        <div className="relative">
+          <div
+            className={cx(
+              'absolute',
+              'border-b',
+              'border-l',
+              'top-2.5',
+              'h-5',
+              'mr-1',
+              'right-[100%]',
+              'rounded-bl',
+              'w-5',
+              'dark:border-neutral-700',
+            )}
+          />
+          <Input
+            label="Pass Address"
+            value={inputValue}
+            type="text"
+            onChange={(evt) => {
+              const value = evt.target.value;
+              setInputValue(value);
+              try {
+                const pk = new PublicKey(value);
+                onChange(pk);
+                setError(undefined);
+              } catch {
+                setError('Invalid address');
+              }
+            }}
+            error={error}
+          />
+        </div>
+      </div>
+    </div>
+  );
+};
+
+// A dropdown of all the available Civic Passes
+const CivicPassDropdown: FC<{
+  className?: string;
+  previousSelected?: PublicKey;
+  onPassTypeChange(value: PublicKey | undefined): void;
+}> = (props) => {
+  const [open, setOpen] = useState(false);
+  const trigger = useRef<HTMLButtonElement>(null);
+  const [selectedPass, setSelectedPass] = useState<CivicPass | undefined>(
+    !!props.previousSelected
+      ? availablePasses.find(
+          (pass) => pass.value === props.previousSelected?.toBase58(),
+        ) ?? other
+      : defaultPass,
+  );
+
+  return (
+    <DropdownMenu.Root open={open} onOpenChange={setOpen}>
+      <div>
+        <DropdownMenu.Trigger
+          className={cx(
+            itemStyles,
+            props.className,
+            open && 'border dark:border-white/40',
+          )}
+          ref={trigger}
+        >
+          <div className={labelStyles}>
+            {selectedPass?.name || 'Select a Civic Pass'}
+          </div>
+          <div className={descriptionStyles}>
+            {selectedPass?.description || ''}
+          </div>
+          <ChevronDownIcon className={cx(iconStyles, open && '-rotate-180')} />
+        </DropdownMenu.Trigger>
+        <DropdownMenu.Portal>
+          <DropdownMenu.Content
+            className="dark space-y-0.5 z-20 w-full"
+            sideOffset={2}
+          >
+            {availablePasses.map((config, i) => (
+              <DropdownMenu.Item
+                className={cx(
+                  itemStyles,
+                  'w-full',
+                  'focus:outline-none',
+                  'dark:focus:bg-neutral-700',
+                )}
+                key={i}
+                onClick={() => {
+                  setSelectedPass(config);
+                  props.onPassTypeChange(
+                    config?.value ? new PublicKey(config.value) : undefined,
+                  );
+                }}
+              >
+                <div className={labelStyles}>{config.name}</div>
+                <div className={descriptionStyles}>{config.description}</div>
+              </DropdownMenu.Item>
+            ))}
+          </DropdownMenu.Content>
+        </DropdownMenu.Portal>
+      </div>
+      {isOther(selectedPass) && (
+        <ManualPassEntry
+          onChange={(manualPassType) => {
+            setSelectedPass(other);
+            props.onPassTypeChange(manualPassType);
+          }}
+          manualPassType={
+            props.previousSelected && selectedPass !== other
+              ? props.previousSelected
+              : undefined
+          }
+        />
+      )}
+    </DropdownMenu.Root>
+  );
+};
+
+interface Props {
+  className?: string;
+  currentPassType?: PublicKey;
+  onPassTypeChange(value: PublicKey | undefined): void;
+}
+
+export function CivicConfigurator(props: Props) {
+  return (
+    <div className={props.className}>
+      <div className="relative">
+        <div className="absolute top-0 left-2 w-0 h-24 border-l dark:border-neutral-700" />
+        <div className="pt-10 pl-8">
+          <div className="text-white font-bold mb-3">
+            What type of verification?
+          </div>
+          <div className="relative">
+            <div
+              className={cx(
+                'absolute',
+                'border-b',
+                'border-l',
+                'top-2.5',
+                'h-5',
+                'mr-1',
+                'right-[100%]',
+                'rounded-bl',
+                'w-5',
+                'dark:border-neutral-700',
+              )}
+            />
+            <CivicPassDropdown
+              previousSelected={props.currentPassType}
+              onPassTypeChange={props.onPassTypeChange}
+            />
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/hub/components/EditRealmConfig/VotingStructureSelector/index.tsx
+++ b/hub/components/EditRealmConfig/VotingStructureSelector/index.tsx
@@ -10,6 +10,7 @@ import cx from '@hub/lib/cx';
 
 import { DEFAULT_NFT_VOTER_PLUGIN } from '@tools/constants';
 
+import { CivicConfigurator } from './CivicConfigurator';
 import { Custom } from './Custom';
 import { NFT } from './NFT';
 
@@ -51,33 +52,24 @@ const labelStyles = cx('font-700', 'dark:text-neutral-50');
 const descriptionStyles = cx('dark:text-neutral-400');
 const iconStyles = cx('fill-neutral-500', 'h-5', 'transition-transform', 'w-4');
 
+type VotingStructure = {
+  votingProgramId?: PublicKey;
+  maxVotingProgramId?: PublicKey;
+  nftCollection?: PublicKey;
+  nftCollectionSize?: number;
+  nftCollectionWeight?: BN;
+  civicPassType?: PublicKey;
+};
+
 interface Props {
   allowNFT?: boolean;
   allowCivic?: boolean;
   allowVSR?: boolean;
   className?: string;
   communityMint: Config['communityMint'];
-  currentStructure: {
-    votingProgramId?: PublicKey;
-    maxVotingProgramId?: PublicKey;
-    nftCollection?: PublicKey;
-    nftCollectionSize?: number;
-    nftCollectionWeight?: BN;
-  };
-  structure: {
-    votingProgramId?: PublicKey;
-    maxVotingProgramId?: PublicKey;
-    nftCollection?: PublicKey;
-    nftCollectionSize?: number;
-    nftCollectionWeight?: BN;
-  };
-  onChange?(value: {
-    votingProgramId?: PublicKey;
-    maxVotingProgramId?: PublicKey;
-    nftCollection?: PublicKey;
-    nftCollectionSize?: number;
-    nftCollectionWeight?: BN;
-  }): void;
+  currentStructure: VotingStructure;
+  structure: VotingStructure;
+  onChange?(value: VotingStructure): void;
 }
 
 function areConfigsEqual(a: Props['structure'], b: Props['structure']) {
@@ -254,6 +246,18 @@ export function VotingStructureSelector(props: Props) {
                 data.nftCollectionWeight = value;
               });
 
+              props.onChange?.(newConfig);
+            }}
+          />
+        )}
+        {isCivicConfig(props.structure) && (
+          <CivicConfigurator
+            className="mt-2"
+            currentPassType={props.currentStructure.civicPassType}
+            onPassTypeChange={(value) => {
+              const newConfig = produce({ ...props.structure }, (data) => {
+                data.civicPassType = value ?? undefined;
+              });
               props.onChange?.(newConfig);
             }}
           />

--- a/hub/components/EditWalletRules/createTransaction.ts
+++ b/hub/components/EditWalletRules/createTransaction.ts
@@ -6,12 +6,10 @@ import {
   VoteTipping,
 } from '@solana/spl-governance';
 import type { Connection, PublicKey } from '@solana/web3.js';
-import BigNumber from 'bignumber.js';
 import BN from 'bn.js';
 
 import { fetchGovernanceAccountByPubkey } from '@hooks/queries/governanceAccount';
 import { fetchMintInfoByPubkey } from '@hooks/queries/mintInfo';
-import queryClient from '@hooks/queries/queryClient';
 import { GovernanceVoteTipping } from '@hub/types/GovernanceVoteTipping';
 
 import { MAX_NUM } from './constants';

--- a/pages/dao/[symbol]/proposal/components/instructions/GatewayPlugin/ConfigureGateway.tsx
+++ b/pages/dao/[symbol]/proposal/components/instructions/GatewayPlugin/ConfigureGateway.tsx
@@ -15,10 +15,10 @@ import { InstructionInputType } from '../inputInstructionType'
 import { PublicKey } from '@solana/web3.js'
 import { getValidatedPublickKey } from '@utils/validations'
 import useGovernanceAssets from '@hooks/useGovernanceAssets'
-import { getRegistrarPDA } from '@utils/plugin/accounts'
 import { AssetAccount } from '@utils/uiTypes/assets'
 import useWalletOnePointOh from '@hooks/useWalletOnePointOh'
 import { useRealmQuery } from '@hooks/queries/realm'
+import {configureCivicRegistrarIx} from "@utils/plugin/gateway";
 
 interface ConfigureGatewayForm {
   governedAccount: AssetAccount | undefined
@@ -55,24 +55,11 @@ const ConfigureGatewayPlugin = ({
       form!.governedAccount?.governance?.account &&
       wallet?.publicKey
     ) {
-      const remainingAccounts = form!.predecessor
-        ? [{ pubkey: form!.predecessor, isSigner: false, isWritable: false }]
-        : []
-      const { registrar } = await getRegistrarPDA(
-        realm!.pubkey,
-        realm!.account.communityMint,
-        gatewayClient!.program.programId
+      const configureRegistrarTx = await configureCivicRegistrarIx(
+          realm!,
+          gatewayClient!,
+          chosenGatekeeperNetwork!,
       )
-      const configureRegistrarTx = await gatewayClient!.program.methods
-        .configureRegistrar(false)
-        .accounts({
-          registrar,
-          realm: realm!.pubkey,
-          realmAuthority: realm!.account.authority!,
-          gatekeeperNetwork: chosenGatekeeperNetwork,
-        })
-        .remainingAccounts(remainingAccounts)
-        .instruction()
       serializedInstruction = serializeInstructionToBase64(configureRegistrarTx)
     }
     return {

--- a/pages/dao/[symbol]/proposal/components/instructions/GatewayPlugin/CreateRegistrar.tsx
+++ b/pages/dao/[symbol]/proposal/components/instructions/GatewayPlugin/CreateRegistrar.tsx
@@ -4,12 +4,10 @@ import {
   Governance,
   ProgramAccount,
   serializeInstructionToBase64,
-  SYSTEM_PROGRAM_ID,
 } from '@solana/spl-governance'
 import { validateInstruction } from '@utils/instructionTools'
 import { NameValue, UiInstruction } from '@utils/uiTypes/proposalCreationTypes'
 
-import useRealm from '@hooks/useRealm'
 import useVotePluginsClientStore from 'stores/useVotePluginsClientStore'
 import { NewProposalContext } from '../../../new'
 import InstructionForm, { InstructionInput } from '../FormCreator'
@@ -19,9 +17,10 @@ import useGovernanceAssets from '@hooks/useGovernanceAssets'
 import { PublicKey } from '@solana/web3.js'
 import { InformationCircleIcon } from '@heroicons/react/outline'
 import Tooltip from '@components/Tooltip'
-import { getRegistrarPDA } from '@utils/plugin/accounts'
 import useWalletOnePointOh from '@hooks/useWalletOnePointOh'
 import { useRealmQuery } from '@hooks/queries/realm'
+import {availablePasses} from "../../../../../../../GatewayPlugin/config";
+import {createCivicRegistrarIx} from "@utils/plugin/gateway";
 
 interface CreateGatewayRegistrarForm {
   governedAccount: AssetAccount | undefined
@@ -38,7 +37,6 @@ const CreateGatewayPluginRegistrar = ({
   governance: ProgramAccount<Governance> | null
 }) => {
   const realm = useRealmQuery().data?.result
-  const { realmInfo } = useRealm()
   const gatewayClient = useVotePluginsClientStore((s) => s.state.gatewayClient)
   const { assetAccounts } = useGovernanceAssets()
   const wallet = useWalletOnePointOh()
@@ -63,30 +61,12 @@ const CreateGatewayPluginRegistrar = ({
       form!.governedAccount?.governance?.account &&
       wallet?.publicKey
     ) {
-      const { registrar } = await getRegistrarPDA(
-        realm!.pubkey,
-        realm!.account.communityMint,
-        gatewayClient!.program.programId
+      const createRegistrarIx = await createCivicRegistrarIx(
+        realm!,
+          wallet.publicKey!,
+          gatewayClient!,
+          chosenGatekeeperNetwork!,
       )
-
-      const remainingAccounts = form!.predecessor
-        ? [{ pubkey: form!.predecessor, isSigner: false, isWritable: false }]
-        : []
-
-      const createRegistrarIx = await gatewayClient!.program.methods
-        .createRegistrar(false)
-        .accounts({
-          registrar,
-          realm: realm!.pubkey,
-          governanceProgramId: realmInfo!.programId,
-          realmAuthority: realm!.account.authority!,
-          governingTokenMint: realm!.account.communityMint!,
-          gatekeeperNetwork: chosenGatekeeperNetwork,
-          payer: wallet.publicKey!,
-          systemProgram: SYSTEM_PROGRAM_ID,
-        })
-        .remainingAccounts(remainingAccounts)
-        .instruction()
       serializedInstruction = serializeInstructionToBase64(createRegistrarIx)
     }
     return {
@@ -146,28 +126,7 @@ const CreateGatewayPluginRegistrar = ({
           </span>
         </Tooltip>
       ),
-      options: [
-        {
-          name: 'Bot Resistance',
-          value: 'ignREusXmGrscGNUesoU9mxfds9AiYTezUKex2PsZV6',
-        },
-        {
-          name: 'Uniqueness',
-          value: 'uniqobk8oGh4XBLMqM68K8M2zNu3CdYX7q5go7whQiv',
-        },
-        {
-          name: 'ID Verification',
-          value: 'bni1ewus6aMxTxBi5SAfzEmmXLf8KcVFRmTfproJuKw',
-        },
-        {
-          name: 'ID Verification for DeFi',
-          value: 'gatbGF9DvLAw3kWyn1EmH5Nh1Sqp8sTukF7yaQpSc71',
-        },
-        {
-          name: 'Other',
-          value: '',
-        },
-      ],
+      options: availablePasses as any,
     },
     {
       label: 'Other Pass',

--- a/utils/plugin/gateway.ts
+++ b/utils/plugin/gateway.ts
@@ -1,0 +1,84 @@
+import {getRegistrarPDA} from "@utils/plugin/accounts";
+import {ProgramAccount, Realm, SYSTEM_PROGRAM_ID} from "@solana/spl-governance";
+import {GatewayClient} from "@solana/governance-program-library";
+import {PublicKey} from "@solana/web3.js";
+
+// Get the registrar account for a given realm
+export const tryGetRegistar = async (
+    realm: ProgramAccount<Realm>,
+    gatewayClient: GatewayClient,
+) => {
+    const {registrar} = await getRegistrarPDA(
+        realm.pubkey,
+        realm.account.communityMint,
+        gatewayClient.program.programId
+    )
+    try {
+        return await gatewayClient.program.account.registrar.fetch(
+            registrar
+        )
+    } catch (e) {
+        return null
+    }
+};
+
+// Create an instruction to create a registrar account for a given realm
+export const createCivicRegistrarIx = async (
+    realm: ProgramAccount<Realm>,
+    payer: PublicKey,
+    gatewayClient: GatewayClient,
+    gatekeeperNetwork: PublicKey,
+    predecessor?: PublicKey
+) => {
+    const { registrar } = await getRegistrarPDA(
+        realm.pubkey,
+        realm.account.communityMint,
+        gatewayClient.program.programId
+    )
+
+    const remainingAccounts = predecessor
+        ? [{ pubkey: predecessor, isSigner: false, isWritable: false }]
+        : []
+
+    return gatewayClient!.program.methods
+        .createRegistrar(false)
+        .accounts({
+            registrar,
+            realm: realm.pubkey,
+            governanceProgramId: realm.owner,
+            realmAuthority: realm.account.authority!,
+            governingTokenMint: realm.account.communityMint!,
+            gatekeeperNetwork,
+            payer,
+            systemProgram: SYSTEM_PROGRAM_ID,
+        })
+        .remainingAccounts(remainingAccounts)
+        .instruction()
+}
+
+// Create an instruction to configure a registrar account for a given realm
+export const configureCivicRegistrarIx = async (
+    realm: ProgramAccount<Realm>,
+    gatewayClient: GatewayClient,
+    gatekeeperNetwork: PublicKey,
+    predecessor?: PublicKey
+) => {
+    const { registrar } = await getRegistrarPDA(
+        realm.pubkey,
+        realm.account.communityMint,
+        gatewayClient.program.programId
+    )
+    const remainingAccounts = predecessor
+        ? [{ pubkey: predecessor, isSigner: false, isWritable: false }]
+        : []
+    return gatewayClient.program.methods
+        .configureRegistrar(false)
+        .accounts({
+            registrar,
+            realm: realm.pubkey,
+            realmAuthority: realm.account.authority!,
+            gatekeeperNetwork: gatekeeperNetwork,
+        })
+        .remainingAccounts(remainingAccounts)
+        .instruction()
+}


### PR DESCRIPTION
The UI was set up to allow selecting Civic as an option for a voting plugin, however selecting this option didn't work.


https://github.com/solana-labs/governance-ui/assets/5008805/39a307a0-3474-449f-9b52-49f8850cc924



This PR adds

- Wiring this option up to creating the correct instructions (creating or configuring the gateway registrar for the DAO)
- UI to select the pass type (defaulting to Uniqueness)


