### PR TITLE
Generalize VanillaVotingPower

### DIFF
--- a/components/GovernancePower/GovernancePowerForRole.tsx
+++ b/components/GovernancePower/GovernancePowerForRole.tsx
@@ -70,6 +70,8 @@ export default function GovernancePowerForRole({
           </div>
         ) : kind === 'VSR' ? (
           <LockedCommunityVotingPower />
+        ) : kind === 'pyth' ? (
+          <VanillaVotingPower role="community" {...props} />
         ) : kind === 'NFT' ? (
           <NftVotingPower />
         ) : kind === 'HeliumVSR' ? (

--- a/components/GovernancePower/Vanilla/VanillaVotingPower.tsx
+++ b/components/GovernancePower/Vanilla/VanillaVotingPower.tsx
@@ -5,11 +5,7 @@ import { useTokenOwnerRecordsDelegatedToUser } from '@hooks/queries/tokenOwnerRe
 import { useRealmQuery } from '@hooks/queries/realm'
 import { useMintInfoByPubkeyQuery } from '@hooks/queries/mintInfo'
 import { useConnection } from '@solana/wallet-adapter-react'
-import { getVanillaGovpower } from '@hooks/queries/governancePower'
-import {
-  useAddressQuery_CommunityTokenOwner,
-  useAddressQuery_CouncilTokenOwner,
-} from '@hooks/queries/addresses/tokenOwnerRecord'
+import { getVanillaGovpower, useGovernancePowerAsync } from '@hooks/queries/governancePower'
 import { useAsync } from 'react-async-hook'
 import BN from 'bn.js'
 import { getMintMetadata } from '@components/instructions/programs/splToken'
@@ -36,12 +32,8 @@ export default function VanillaVotingPower({
   const realm = useRealmQuery().data?.result
   const realmConfig = useRealmConfigQuery().data?.result
 
-  const { data: communityTOR } = useAddressQuery_CommunityTokenOwner()
-  const { data: councilTOR } = useAddressQuery_CouncilTokenOwner()
-
   const { connection } = useConnection()
 
-  const relevantTOR = role === 'community' ? communityTOR : councilTOR
   const relevantMint =
     role === 'community'
       ? realm?.account.communityMint
@@ -49,11 +41,7 @@ export default function VanillaVotingPower({
 
   const mintInfo = useMintInfoByPubkeyQuery(relevantMint).data?.result
 
-  const { result: personalAmount } = useAsync(
-    async () => relevantTOR && getVanillaGovpower(connection, relevantTOR),
-    [connection, relevantTOR]
-  )
-
+  const {result : personalAmount} = useGovernancePowerAsync(role);
   // If the user is using a delegator, we want to show that and not count the other delegators
   const selectedDelegator = useSelectedDelegatorStore((s) =>
     role === 'community' ? s.communityDelegator : s.councilDelegator


### PR DESCRIPTION
The main purpose of this PR was to fix the display of voting power for the Pyth DAO.

I realized VanillaVotingPower can be made generic pretty easily by querying the voter weight using useGovernancePowerAsync. 

Let me know what you think!