### PR TITLE
show members tab if council exists

### DIFF
--- a/components/RealmHeader.tsx
+++ b/components/RealmHeader.tsx
@@ -11,6 +11,10 @@ import { tryParsePublicKey } from '@tools/core/pubkey'
 import { useRealmQuery } from '@hooks/queries/realm'
 import { useRealmConfigQuery } from '@hooks/queries/realmConfig'
 import { GoverningTokenType } from '@solana/spl-governance'
+import { determineVotingPowerType } from '@hooks/queries/governancePower'
+import { useAsync } from 'react-async-hook'
+import useSelectedRealmPubkey from '@hooks/selectedRealm/useSelectedRealmPubkey'
+import { useConnection } from '@solana/wallet-adapter-react'
 
 const RealmHeader = () => {
   const { fmtUrlWithCluster } = useQueryContext()
@@ -25,6 +29,14 @@ const RealmHeader = () => {
 
   const [isBackNavVisible, setIsBackNavVisible] = useState(true)
 
+  const { connection } = useConnection()
+  const realmPk = useSelectedRealmPubkey()
+
+  const { result: kind } = useAsync(async () => {
+    if (realmPk === undefined) return undefined
+    return determineVotingPowerType(connection, realmPk, 'community')
+  }, [connection, realmPk])
+  const membersTabIsCouncilOnly = !(kind === 'vanilla' || kind === 'NFT')
   const councilExists =
     realm?.account.config.councilMint !== undefined &&
     config?.account.councilTokenConfig?.tokenType !== GoverningTokenType.Dormant
@@ -83,11 +95,11 @@ const RealmHeader = () => {
               </a>
             </Link>
           )}
-          {councilExists && (
+          {(!membersTabIsCouncilOnly || councilExists) && (
             <Link href={fmtUrlWithCluster(`/dao/${symbol}/members`)}>
               <a className="flex items-center text-sm cursor-pointer default-transition text-fgd-2 hover:text-fgd-3">
                 <UsersIcon className="flex-shrink-0 w-5 h-5 mr-1" />
-                Members
+                {membersTabIsCouncilOnly ? 'Council' : 'Members'}
               </a>
             </Link>
           )}

--- a/components/RealmHeader.tsx
+++ b/components/RealmHeader.tsx
@@ -10,7 +10,7 @@ import { getRealmExplorerHost } from 'tools/routing'
 import { tryParsePublicKey } from '@tools/core/pubkey'
 import { useRealmQuery } from '@hooks/queries/realm'
 import { useRealmConfigQuery } from '@hooks/queries/realmConfig'
-import { NFT_PLUGINS_PKS } from '@constants/plugins'
+import { GoverningTokenType } from '@solana/spl-governance'
 
 const RealmHeader = () => {
   const { fmtUrlWithCluster } = useQueryContext()
@@ -24,6 +24,10 @@ const RealmHeader = () => {
   const realmUrl = `https://${explorerHost}/#/realm/${realmInfo?.realmId.toBase58()}?programId=${realmInfo?.programId.toBase58()}`
 
   const [isBackNavVisible, setIsBackNavVisible] = useState(true)
+
+  const councilExists =
+    realm?.account.config.councilMint !== undefined &&
+    config?.account.councilTokenConfig?.tokenType !== GoverningTokenType.Dormant
 
   useEffect(() => {
     setIsBackNavVisible(realmInfo?.symbol !== REALM)
@@ -68,17 +72,6 @@ const RealmHeader = () => {
           <div className="w-40 h-10 rounded-md animate-pulse bg-bkg-3" />
         )}
         <div className="flex items-center space-x-4">
-          {(!config?.account.communityTokenConfig.voterWeightAddin ||
-            NFT_PLUGINS_PKS.includes(
-              config?.account.communityTokenConfig.voterWeightAddin.toBase58()
-            )) && (
-            <Link href={fmtUrlWithCluster(`/dao/${symbol}/members`)}>
-              <a className="flex items-center text-sm cursor-pointer default-transition text-fgd-2 hover:text-fgd-3">
-                <UsersIcon className="flex-shrink-0 w-5 h-5 mr-1" />
-                Members
-              </a>
-            </Link>
-          )}
           {vsrMode === 'default' && (
             <Link href={fmtUrlWithCluster(`/dao/${symbol}/token-stats`)}>
               <a className="flex items-center text-sm cursor-pointer default-transition text-fgd-2 hover:text-fgd-3">
@@ -87,6 +80,14 @@ const RealmHeader = () => {
                   ? realm?.account.name
                   : symbol}{' '}
                 stats
+              </a>
+            </Link>
+          )}
+          {councilExists && (
+            <Link href={fmtUrlWithCluster(`/dao/${symbol}/members`)}>
+              <a className="flex items-center text-sm cursor-pointer default-transition text-fgd-2 hover:text-fgd-3">
+                <UsersIcon className="flex-shrink-0 w-5 h-5 mr-1" />
+                Members
               </a>
             </Link>
           )}

--- a/pages/dao/[symbol]/members/index.tsx
+++ b/pages/dao/[symbol]/members/index.tsx
@@ -1,18 +1,8 @@
-import { NFT_PLUGINS_PKS } from '@constants/plugins'
 import Members from './Members'
-import { useRealmConfigQuery } from '@hooks/queries/realmConfig'
 const MembersPage = () => {
-  const config = useRealmConfigQuery().data?.result
-  const currentPluginPk = config?.account.communityTokenConfig.voterWeightAddin
-  const isNftMode =
-    (currentPluginPk &&
-      NFT_PLUGINS_PKS.includes(currentPluginPk?.toBase58())) ||
-    false
   return (
     <div>
-      {!config?.account.communityTokenConfig.voterWeightAddin || isNftMode ? (
-        <Members />
-      ) : null}
+      <Members />
     </div>
   )
 }


### PR DESCRIPTION
Previously: the "Members" tab was hidden for plugins
Now: it's shown iff there is a council, and in this case the view only shows council members rather than all members.

Note: it still shows their vanilla community votes in this view. I didn't want to spend too much time on it for now unless asked.