### PR TITLE
Filter delegators query

### DIFF
--- a/VoteStakeRegistry/components/TokenBalance/VSRVotingPower.tsx
+++ b/VoteStakeRegistry/components/TokenBalance/VSRVotingPower.tsx
@@ -68,7 +68,7 @@ export default function VSRCommunityVotingPower(props: Props) {
         .shiftedBy(-mint.decimals)
     : new BigNumber('0')
 
-  const delegatedTors = useTokenOwnerRecordsDelegatedToUser()
+  const { data: delegatedTors } = useTokenOwnerRecordsDelegatedToUser()
   const selectedDelegator = useSelectedDelegatorStore(
     (s) => s.communityDelegator
   )

--- a/components/GovernancePower/Vanilla/VanillaVotingPower.tsx
+++ b/components/GovernancePower/Vanilla/VanillaVotingPower.tsx
@@ -59,7 +59,7 @@ export default function VanillaVotingPower({
     role === 'community' ? s.communityDelegator : s.councilDelegator
   )
 
-  const torsDelegatedToUser = useTokenOwnerRecordsDelegatedToUser()
+  const { data: torsDelegatedToUser } = useTokenOwnerRecordsDelegatedToUser()
 
   const { result: delegatorsAmount } = useAsync(
     async () =>

--- a/components/SelectPrimaryDelegators.tsx
+++ b/components/SelectPrimaryDelegators.tsx
@@ -22,7 +22,7 @@ const SelectPrimaryDelegators = () => {
   const walletId = wallet?.publicKey?.toBase58()
   const realm = useRealmQuery().data?.result
 
-  const delegatesArray = useTokenOwnerRecordsDelegatedToUser()
+  const { data: delegatesArray } = useTokenOwnerRecordsDelegatedToUser()
 
   // returns array of community tokenOwnerRecords that connected wallet has been delegated
   const communityTorsDelegatedToUser = useMemo(

--- a/components/VotePanel/useDelegators.ts
+++ b/components/VotePanel/useDelegators.ts
@@ -14,7 +14,7 @@ const useDelegators = (role: 'community' | 'council' | undefined) => {
       ? realm?.account.communityMint
       : realm?.account.config.councilMint
 
-  const torsDelegatedToUser = useTokenOwnerRecordsDelegatedToUser()
+  const { data: torsDelegatedToUser } = useTokenOwnerRecordsDelegatedToUser()
   const relevantDelegators =
     relevantMint &&
     torsDelegatedToUser?.filter((x) =>

--- a/hooks/useVotingTokenOwnerRecords.ts
+++ b/hooks/useVotingTokenOwnerRecords.ts
@@ -9,7 +9,7 @@ import { getTokenOwnerRecordAddress } from '@solana/spl-governance'
  * Namely, this would be the user + any delegates that are enabled (by default, they all are)
  */
 const useVotingTokenOwnerRecords = () => {
-  const delegated = useTokenOwnerRecordsDelegatedToUser()
+  const { data: delegated } = useTokenOwnerRecordsDelegatedToUser()
   const realm = useRealmQuery().data?.result
   const wallet = useWalletOnePointOh()
 

--- a/pages/dao/[symbol]/account/DelegatorOptions.tsx
+++ b/pages/dao/[symbol]/account/DelegatorOptions.tsx
@@ -4,7 +4,7 @@ import { useTokenOwnerRecordsDelegatedToUser } from '@hooks/queries/tokenOwnerRe
 import DelegatorsList from './DelegatorsList'
 
 const DelegatorOptions = () => {
-  const delegatesArray = useTokenOwnerRecordsDelegatedToUser()
+  const { data: delegatesArray } = useTokenOwnerRecordsDelegatedToUser()
 
   return delegatesArray === undefined || delegatesArray.length < 1 ? null : (
     <div className="bg-bkg-2 p-4 md:p-6 rounded-lg">

--- a/pages/dao/[symbol]/account/DelegatorsList.tsx
+++ b/pages/dao/[symbol]/account/DelegatorsList.tsx
@@ -37,7 +37,7 @@ const DelegatorCheckbox = ({
 const DelegatorsList = () => {
   const realm = useRealmQuery().data?.result
 
-  const delegatesArray = useTokenOwnerRecordsDelegatedToUser()
+  const { data: delegatesArray } = useTokenOwnerRecordsDelegatedToUser()
 
   // returns array of community tokenOwnerRecords that connected wallet has been delegated
   const communityTorsDelegatedToUser = useMemo(


### PR DESCRIPTION
So we need to get every token owner record delegated to the user, so that they can act on behalf of delegators.

Previously we would simply fetch ALL token owner records and filter client side. This was a big problem for Pyth DAO which has a lot of users (94MB worth!)

This PR makes the GPA filter upon the governanceDelegate field.