### PR TITLE
Change the name of Our DAO from GRLA DAO to GARBAGE DAO

### DIFF
--- a/public/realms/mainnet-beta.json
+++ b/public/realms/mainnet-beta.json
@@ -3447,5 +3447,13 @@
     "ogImage": "/realms/MOUTAI/mdao.jpg",
     "website": "https://www.moutaicoin.co/",
     "twitter": "@Moutai_Sol"
+  },
+  {
+    "symbol": "GARBAGE",
+    "displayName": "GARBAGE DAO",
+    "programId": "GovER5Lthms3bLBqWub97yVrMmEogzX7xNjdXpPPCVZw",
+    "realmId": "GgF6fHb3iM3Um5DtvwbZvpGpYTzYnr1RmZr4NkwHveGp",
+    "website": "",
+    "twitter": ""
   }
 ]


### PR DESCRIPTION
We are starting fresh on our GRLA DAO, we played around with the name GRLA DAO while setting up DAO and learning about Realms, understanding it's functionality and use case for us.

Hence we are renaming our old DAO to Garbage DAO and starting fresh on GRLA DAO with actual implementation. 