### PR TITLE
Fix typos

### DIFF
--- a/HeliumVotePlugin/hooks/useSplitPosition.ts
+++ b/HeliumVotePlugin/hooks/useSplitPosition.ts
@@ -186,7 +186,7 @@ export const useSplitPosition = () => {
           sequenceType: SequenceType.Sequential,
         }))
 
-        notify({ message: 'Spliting Position' })
+        notify({ message: 'Splitting Position' })
         await sendTransactionsV3({
           transactionInstructions: txsChunks,
           wallet,

--- a/HeliumVotePlugin/hooks/useTransferPosition.ts
+++ b/HeliumVotePlugin/hooks/useTransferPosition.ts
@@ -104,7 +104,7 @@ export const useTransferPosition = () => {
           )
         }
 
-        notify({ message: 'Transfering' })
+        notify({ message: 'Transferring' })
         await sendTransactionsV3({
           transactionInstructions: [
             {


### PR DESCRIPTION
1. Fix `HeliumVotePlugin/hooks/useSplitPosition.ts`   typo
2. Fix `HeliumVotePlugin/hooks/useTransferPosition.ts`   typo