### PR TITLE
update token record preference

### DIFF
--- a/hooks/useCreateProposal.ts
+++ b/hooks/useCreateProposal.ts
@@ -55,14 +55,12 @@ export default function useCreateProposal() {
     const { result: selectedGovernance } = await fetchGovernanceByPubkey(
       connection.current,
       governance.pubkey
-    )
+    )    
+    const ownTokenRecord = ownVoterWeight?.councilTokenRecord ?? ownVoterWeight?.communityTokenRecord
+
+    if (!ownTokenRecord) throw new Error('token owner record does not exist')
     if (!selectedGovernance) throw new Error('governance not found')
     if (!realm) throw new Error()
-
-    const ownTokenRecord = ownVoterWeight?.getTokenRecordToCreateProposal(
-      selectedGovernance.account.config,
-      voteByCouncil
-    ) // TODO just get the token record the normal way
 
     const defaultProposalMint =
       !mint?.supply.isZero() ||
@@ -88,7 +86,7 @@ export default function useCreateProposal() {
       rpcContext,
       realm,
       governance.pubkey,
-      ownTokenRecord!,
+      ownTokenRecord,
       title,
       description,
       proposalMint,
@@ -134,13 +132,11 @@ export default function useCreateProposal() {
       connection.current,
       governance
     )
+    const ownTokenRecord = ownVoterWeight?.councilTokenRecord ?? ownVoterWeight?.communityTokenRecord
+
+    if (!ownTokenRecord) throw new Error('token owner record does not exist')
     if (!selectedGovernance) throw new Error('governance not found')
     if (!realm) throw new Error()
-
-    const ownTokenRecord = ownVoterWeight?.getTokenRecordToCreateProposal(
-      selectedGovernance.account.config,
-      voteByCouncil
-    )
 
     const defaultProposalMint =
       !mint?.supply.isZero() ||
@@ -165,7 +161,7 @@ export default function useCreateProposal() {
       rpcContext,
       realm,
       governance,
-      ownTokenRecord!,
+      ownTokenRecord,
       title,
       description,
       proposalMint,


### PR DESCRIPTION
This commit makes two changes:
1. prefers council token owner record for creating the proposal. If the council token owner record doesn't exist, then community token owner record is picked. 
2. restricts the maximum tokens to 5 for `minimum community governance power required to create a proposal` if the NFT plugin is attached to the DAO and council is not added.