### PR TITLE
fix: restore target in create proposal

### DIFF
--- a/actions/createProposal.ts
+++ b/actions/createProposal.ts
@@ -108,6 +108,7 @@ export const createProposal = async (
     instructions,
     'createProposal',
     createNftTicketsIxs,
+    governance
   )
 
   const proposalAddress = await withCreateProposal(

--- a/utils/uiTypes/VotePlugin.ts
+++ b/utils/uiTypes/VotePlugin.ts
@@ -121,10 +121,11 @@ export class VotingClient {
     instructions: TransactionInstruction[],
     type: UpdateVoterWeightRecordTypes,
     createNftActionTicketIxs?: TransactionInstruction[],
+    target? : PublicKey
   ): Promise<ProgramAddresses | undefined> => {
     if (!this.walletPk) return undefined;
 
-    const {pre: preIxes, post: postIxes} = await this.voterWeightPluginDetails.updateVoterWeightRecords(this.walletPk, convertTypeToVoterWeightAction(type))
+    const {pre: preIxes, post: postIxes} = await this.voterWeightPluginDetails.updateVoterWeightRecords(this.walletPk, convertTypeToVoterWeightAction(type), target)
     instructions.push(...preIxes);
     createNftActionTicketIxs?.push(...postIxes);
 


### PR DESCRIPTION
Pyth's withUpdateVoterWeightRecord needs to receive the address of the governance with `createProposal`, this is because it checks the `max_voting_time` field int he governance account.