### PR TITLE
feat: improve program upgrade select

### DIFF
--- a/pages/dao/[symbol]/proposal/components/GovernedAccountSelect.tsx
+++ b/pages/dao/[symbol]/proposal/components/GovernedAccountSelect.tsx
@@ -259,6 +259,7 @@ const GovernedAccountSelect = ({
         </div>
         <div>
           <div className="mb-0.5 truncate w-full">
+            Program:{' '}
             {programName ? programName : abbreviateAddress(value.pubkey)}
           </div>
 

--- a/pages/dao/[symbol]/proposal/components/GovernedAccountSelect.tsx
+++ b/pages/dao/[symbol]/proposal/components/GovernedAccountSelect.tsx
@@ -71,7 +71,7 @@ const GovernedAccountSelect = ({
   label?: string
   noMaxWidth?: boolean
   autoSelectFirst?: boolean
-  type?: 'mint' | 'token' | 'wallet'
+  type?: 'mint' | 'token' | 'wallet' | 'program'
 }) => {
   const realm = useRealm()
   const treasuryInfo = useTreasuryInfo(false)
@@ -97,6 +97,9 @@ const GovernedAccountSelect = ({
         | ReturnType<typeof getSolAccountLabel>
     }[]
   >([])
+  const [programs, setPrograms] = useState<
+  AssetAccount[]
+>([])
   const programId = realm.realmInfo?.programId
 
   useEffect(() => {
@@ -118,6 +121,11 @@ const GovernedAccountSelect = ({
             : getTokenAccountLabelInfo(account),
         }))
     )
+    setPrograms(
+      governedAccounts
+        .filter((account) => account.type === AccountType.PROGRAM)
+    )
+
 
     if (programId) {
       const governances = new Set<string>([])
@@ -235,20 +243,6 @@ const GovernedAccountSelect = ({
       return null
     }
 
-    const wallet = wallets.find(({ account }) =>
-      account.pubkey.equals(value.pubkey)
-    )
-
-    if (!wallet) {
-      return null
-    }
-
-    const accountName = value.isSol
-      ? getSolAccountLabel(value).tokenAccountName
-      : value.isToken
-      ? getTokenAccountLabelInfo(value).tokenAccountName
-      : getMintAccountLabelInfo(value).mintAccountName
-
     const walletInfo = RE.isOk(treasuryInfo)
       ? treasuryInfo.data.wallets.find(
           (wallet) =>
@@ -264,20 +258,12 @@ const GovernedAccountSelect = ({
           <UnselectedWalletIcon className="h-10 w-10 stroke-white/50" />
         </div>
         <div>
-          {accountName ? (
-            <div className="mb-0.5 truncate w-full">{accountName}</div>
-          ) : (
             <div className="mb-0.5 truncate w-full">
-              {abbreviateAddress(wallet.walletAddress)}
+              {programName ? programName : abbreviateAddress(value.pubkey)}
             </div>
-          )}
-          <div className="space-y-0.5 text-xs text-fgd-3">
-            <div>Rules: {abbreviateAddress(value.governance.pubkey)}</div>
-          </div>
 
           <div className="space-y-0.5 text-xs text-fgd-3">
-            Program:{' '}
-            {programName ? programName : abbreviateAddress(value.pubkey)}
+            <div>Rules: {abbreviateAddress(value.governance.pubkey)}</div>
           </div>
         </div>
         {walletInfo ? (
@@ -448,7 +434,7 @@ const GovernedAccountSelect = ({
             ? getTokenView(value)
             : type === 'mint'
             ? getMintView(value)
-            : value?.type === AccountType.PROGRAM
+            : type === 'program'
             ? getProgramView(value, true)
             : getWalletView(value, true)
         }
@@ -501,6 +487,29 @@ const GovernedAccountSelect = ({
                 ) : null
               })
               .filter(exists)
+          : type === 'program' ?
+
+            programs
+              .filter((program) =>
+                !shouldBeGoverned
+                  ? !shouldBeGoverned
+                  : program.governance?.pubkey.toBase58() ===
+                    governance?.pubkey?.toBase58()
+              )
+              .map((program) => {
+                const label = getProgramView(program)
+
+                return label ? (
+                  <Select.Option
+                    className="border-red"
+                    key={program.pubkey.toBase58()}
+                    value={program}
+                  >
+                    {label}
+                  </Select.Option>
+                ) : null
+              })
+              .filter(exists)
           : wallets
               .filter((wallet) =>
                 !shouldBeGoverned
@@ -509,10 +518,7 @@ const GovernedAccountSelect = ({
                     governance?.pubkey?.toBase58()
               )
               .map((wallet) => {
-                const label =
-                  wallet.account.type === AccountType.PROGRAM
-                    ? getProgramView(wallet.account)
-                    : getWalletView(wallet.account)
+                const label = getWalletView(wallet.account)
 
                 return label ? (
                   <Select.Option

--- a/pages/dao/[symbol]/proposal/components/GovernedAccountSelect.tsx
+++ b/pages/dao/[symbol]/proposal/components/GovernedAccountSelect.tsx
@@ -93,13 +93,13 @@ const GovernedAccountSelect = ({
     {
       account: AssetAccount
       info:
-        | ReturnType<typeof getTokenAccountLabelInfo>
-        | ReturnType<typeof getSolAccountLabel>
+      | ReturnType<typeof getTokenAccountLabelInfo>
+      | ReturnType<typeof getSolAccountLabel>
     }[]
   >([])
   const [programs, setPrograms] = useState<
-  AssetAccount[]
->([])
+    AssetAccount[]
+  >([])
   const programId = realm.realmInfo?.programId
 
   useEffect(() => {
@@ -145,8 +145,8 @@ const GovernedAccountSelect = ({
               x.extensions.transferAddress?.equals(walletAddress)
             )
               ? governedAccounts.find((x) =>
-                  x.extensions.transferAddress?.equals(walletAddress)
-                )!
+                x.extensions.transferAddress?.equals(walletAddress)
+              )!
               : account,
             governance: account.governance.pubkey,
             walletAddress,
@@ -184,14 +184,14 @@ const GovernedAccountSelect = ({
     const name = value.isSol
       ? getSolAccountLabel(value).tokenAccountName
       : value.isToken
-      ? getTokenAccountLabelInfo(value).tokenAccountName
-      : getMintAccountLabelInfo(value).mintAccountName
+        ? getTokenAccountLabelInfo(value).tokenAccountName
+        : getMintAccountLabelInfo(value).mintAccountName
     const accountName = name ? name : getAccountName(wallet.walletAddress)
     const walletInfo = RE.isOk(treasuryInfo)
       ? treasuryInfo.data.wallets.find(
-          (wallet) =>
-            wallet.governanceAddress === value.governance.pubkey.toBase58()
-        )
+        (wallet) =>
+          wallet.governanceAddress === value.governance.pubkey.toBase58()
+      )
       : null
 
     return (
@@ -245,9 +245,9 @@ const GovernedAccountSelect = ({
 
     const walletInfo = RE.isOk(treasuryInfo)
       ? treasuryInfo.data.wallets.find(
-          (wallet) =>
-            wallet.governanceAddress === value.governance.pubkey.toBase58()
-        )
+        (wallet) =>
+          wallet.governanceAddress === value.governance.pubkey.toBase58()
+      )
       : null
 
     const programName = getAccountName(value.pubkey)
@@ -258,9 +258,9 @@ const GovernedAccountSelect = ({
           <UnselectedWalletIcon className="h-10 w-10 stroke-white/50" />
         </div>
         <div>
-            <div className="mb-0.5 truncate w-full">
-              {programName ? programName : abbreviateAddress(value.pubkey)}
-            </div>
+          <div className="mb-0.5 truncate w-full">
+            {programName ? programName : abbreviateAddress(value.pubkey)}
+          </div>
 
           <div className="space-y-0.5 text-xs text-fgd-3">
             <div>Rules: {abbreviateAddress(value.governance.pubkey)}</div>
@@ -350,9 +350,9 @@ const GovernedAccountSelect = ({
 
     const walletInfo = RE.isOk(treasuryInfo)
       ? treasuryInfo.data.wallets.find(
-          (wallet) =>
-            wallet.governanceAddress === value.governance.pubkey.toBase58()
-        )
+        (wallet) =>
+          wallet.governanceAddress === value.governance.pubkey.toBase58()
+      )
       : null
 
     const mintInfo = walletInfo?.assets.find(
@@ -419,9 +419,9 @@ const GovernedAccountSelect = ({
 
   const walletInfo = RE.isOk(treasuryInfo)
     ? treasuryInfo.data.wallets.find(
-        (wallet) =>
-          wallet.governanceAddress === value?.governance.pubkey.toBase58()
-      )
+      (wallet) =>
+        wallet.governanceAddress === value?.governance.pubkey.toBase58()
+    )
     : null
 
   return (
@@ -433,10 +433,10 @@ const GovernedAccountSelect = ({
           type === 'token'
             ? getTokenView(value)
             : type === 'mint'
-            ? getMintView(value)
-            : type === 'program'
-            ? getProgramView(value, true)
-            : getWalletView(value, true)
+              ? getMintView(value)
+              : type === 'program'
+                ? getProgramView(value, true)
+                : getWalletView(value, true)
         }
         placeholder="Please select..."
         value={value?.pubkey}
@@ -445,33 +445,33 @@ const GovernedAccountSelect = ({
       >
         {type === 'token'
           ? tokens
-              .filter((token) =>
-                !shouldBeGoverned
-                  ? !shouldBeGoverned
-                  : token.account?.governance?.pubkey.toBase58() ===
-                    governance?.pubkey?.toBase58()
-              )
-              .map((token) => {
-                const label = getTokenView(token.account)
+            .filter((token) =>
+              !shouldBeGoverned
+                ? !shouldBeGoverned
+                : token.account?.governance?.pubkey.toBase58() ===
+                governance?.pubkey?.toBase58()
+            )
+            .map((token) => {
+              const label = getTokenView(token.account)
 
-                return label ? (
-                  <Select.Option
-                    className="border-red"
-                    key={token.account.pubkey.toBase58()}
-                    value={token.account}
-                  >
-                    {label}
-                  </Select.Option>
-                ) : null
-              })
-              .filter(exists)
+              return label ? (
+                <Select.Option
+                  className="border-red"
+                  key={token.account.pubkey.toBase58()}
+                  value={token.account}
+                >
+                  {label}
+                </Select.Option>
+              ) : null
+            })
+            .filter(exists)
           : type === 'mint'
-          ? mints
+            ? mints
               .filter((mint) =>
                 !shouldBeGoverned
                   ? !shouldBeGoverned
                   : mint.account?.governance?.pubkey.toBase58() ===
-                    governance?.pubkey?.toBase58()
+                  governance?.pubkey?.toBase58()
               )
               .map((mint) => {
                 const label = getMintView(mint.account)
@@ -487,50 +487,50 @@ const GovernedAccountSelect = ({
                 ) : null
               })
               .filter(exists)
-          : type === 'program' ?
+            : type === 'program' ?
 
-            programs
-              .filter((program) =>
-                !shouldBeGoverned
-                  ? !shouldBeGoverned
-                  : program.governance?.pubkey.toBase58() ===
+              programs
+                .filter((program) =>
+                  !shouldBeGoverned
+                    ? !shouldBeGoverned
+                    : program.governance?.pubkey.toBase58() ===
                     governance?.pubkey?.toBase58()
-              )
-              .map((program) => {
-                const label = getProgramView(program)
+                )
+                .map((program) => {
+                  const label = getProgramView(program)
 
-                return label ? (
-                  <Select.Option
-                    className="border-red"
-                    key={program.pubkey.toBase58()}
-                    value={program}
-                  >
-                    {label}
-                  </Select.Option>
-                ) : null
-              })
-              .filter(exists)
-          : wallets
-              .filter((wallet) =>
-                !shouldBeGoverned
-                  ? !shouldBeGoverned
-                  : wallet.account?.governance?.pubkey.toBase58() ===
+                  return label ? (
+                    <Select.Option
+                      className="border-red"
+                      key={program.pubkey.toBase58()}
+                      value={program}
+                    >
+                      {label}
+                    </Select.Option>
+                  ) : null
+                })
+                .filter(exists)
+              : wallets
+                .filter((wallet) =>
+                  !shouldBeGoverned
+                    ? !shouldBeGoverned
+                    : wallet.account?.governance?.pubkey.toBase58() ===
                     governance?.pubkey?.toBase58()
-              )
-              .map((wallet) => {
-                const label = getWalletView(wallet.account)
+                )
+                .map((wallet) => {
+                  const label = getWalletView(wallet.account)
 
-                return label ? (
-                  <Select.Option
-                    className="border-red"
-                    key={wallet.account.pubkey.toBase58()}
-                    value={wallet.account}
-                  >
-                    {label}
-                  </Select.Option>
-                ) : null
-              })
-              .filter(exists)}
+                  return label ? (
+                    <Select.Option
+                      className="border-red"
+                      key={wallet.account.pubkey.toBase58()}
+                      value={wallet.account}
+                    >
+                      {label}
+                    </Select.Option>
+                  ) : null
+                })
+                .filter(exists)}
       </Select>
       {value && walletInfo && (
         <div className="text-white/50 max-w-lg mt-2">

--- a/pages/dao/[symbol]/proposal/components/instructions/bpfUpgradeableLoader/ProgramUpgrade.tsx
+++ b/pages/dao/[symbol]/proposal/components/instructions/bpfUpgradeableLoader/ProgramUpgrade.tsx
@@ -171,6 +171,7 @@ const ProgramUpgrade = ({
     <>
       <GovernedAccountSelect
         label="Program"
+        type='program'
         governedAccounts={governedProgramAccounts}
         onChange={(value) => {
           handleSetForm({


### PR DESCRIPTION
Currently for the `Common: Upgrade Program` instruction, if a governance has the upgrade authority of more than one program, only one will show up.
This is because of some deduplication logic in GovernedAccountSelect that only allows one governed account per governance.
I want to update the code to allow us to have a governance manage multiple programs.
Before:
![image](https://github.com/solana-labs/governance-ui/assets/59208140/bd161edd-1e3b-4b6d-b2d8-228473c04eee)

After:
![image](https://github.com/solana-labs/governance-ui/assets/59208140/b2c5f1d7-4bb6-4316-b33e-0b3f18bd9484)
