### PR TITLE
Fix: Delegator with no power can create proposal and batch vote

### DIFF
--- a/hooks/useRealmVoterWeightPlugins.ts
+++ b/hooks/useRealmVoterWeightPlugins.ts
@@ -16,6 +16,7 @@ import {SignerWalletAdapter} from "@solana/wallet-adapter-base";
 
 export type UseRealmVoterWeightPluginsReturnType = UseVoterWeightPluginsReturnType & {
   totalCalculatedVoterWeight: CalculatedWeight | undefined,
+  ownVoterWeight: CalculatedWeight | undefined
   voterWeightForWallet: (walletPublicKey: PublicKey) => CalculatedWeight | undefined
   voterWeightPkForWallet: (walletPublicKey: PublicKey) => PublicKey | undefined
 }
@@ -65,6 +66,9 @@ export const useRealmVoterWeightPlugins = (
   const selectedDelegator = useSelectedDelegatorStore((s) =>
     role === 'community' ? s.communityDelegator : s.councilDelegator
   )
+
+  const mainWalletPk = selectedDelegator || wallet?.publicKey
+
   const delegators = useDelegators(role)
   const walletPublicKeys =  getWalletList(
       selectedDelegator,
@@ -96,6 +100,7 @@ export const useRealmVoterWeightPlugins = (
     }
   ) : undefined;
 
+
   // This requires that the index of the wallet in the list of wallets remains consistent with the output voter weights,
   // while not ideal, this is simpler than the alternative, which would be to return a map of wallet public keys to voter weights
   // or something similar.
@@ -111,9 +116,12 @@ export const useRealmVoterWeightPlugins = (
     return nonAggregatedResult.voterWeightPks?.[walletIndex]
   }
 
+  const ownVoterWeight = mainWalletPk ? voterWeightForWallet(mainWalletPk) : undefined
+
   return {
     ...nonAggregatedResult,
     totalCalculatedVoterWeight,
+    ownVoterWeight,
     voterWeightForWallet,
     voterWeightPkForWallet,
   }

--- a/pages/dao/[symbol]/index.tsx
+++ b/pages/dao/[symbol]/index.tsx
@@ -51,7 +51,6 @@ import {
   useRealmProposalsQuery,
 } from '@hooks/queries/proposal'
 import queryClient from '@hooks/queries/queryClient'
-import { useLegacyVoterWeight } from '@hooks/queries/governancePower'
 import { getFeeEstimate } from '@tools/feeEstimate'
 import { createComputeBudgetIx } from '@blockworks-foundation/mango-v4'
 import { useNftClient } from '../../../VoterWeightPlugins/useNftClient'
@@ -80,7 +79,6 @@ const REALM = () => {
   const realmQuery = useRealmQuery()
   const mint = useRealmCommunityMintInfoQuery().data?.result
   const councilMint = useRealmCouncilMintInfoQuery().data?.result
-  const { result: ownVoterWeight } = useLegacyVoterWeight()
   const { realmInfo } = useRealm()
   const proposalsPerPage = 20
   const [filters, setFilters] = useState<Filters>(InitialFilters)

--- a/pages/dao/[symbol]/index.tsx
+++ b/pages/dao/[symbol]/index.tsx
@@ -54,8 +54,9 @@ import queryClient from '@hooks/queries/queryClient'
 import { useLegacyVoterWeight } from '@hooks/queries/governancePower'
 import { getFeeEstimate } from '@tools/feeEstimate'
 import { createComputeBudgetIx } from '@blockworks-foundation/mango-v4'
-import {useNftClient} from "../../../VoterWeightPlugins/useNftClient";
-import {useVotingClients} from "@hooks/useVotingClients";
+import { useNftClient } from '../../../VoterWeightPlugins/useNftClient'
+import { useVotingClients } from '@hooks/useVotingClients'
+import { useRealmVoterWeightPlugins } from '@hooks/useRealmVoterWeightPlugins'
 
 const AccountsCompactWrapper = dynamic(
   () => import('@components/TreasuryAccount/AccountsCompactWrapper')
@@ -96,8 +97,8 @@ const REALM = () => {
     SelectedProposal[]
   >([])
 
-  const votingClients = useVotingClients();
-  const { nftClient } = useNftClient();
+  const votingClients = useVotingClients()
+  const { nftClient } = useNftClient()
   const wallet = useWalletOnePointOh()
   const { connection } = useConnection()
 
@@ -224,18 +225,19 @@ const REALM = () => {
     }
   }, [])
 
+  const {
+    ownVoterWeight: communityOwnVoterWeight,
+  } = useRealmVoterWeightPlugins('community')
+  const { ownVoterWeight: councilOwnVoterWeight } = useRealmVoterWeightPlugins(
+    'council'
+  )
+
   const allVotingProposalsSelected =
     selectedProposals.length === votingProposals?.length
   const hasCommunityVoteWeight =
-    ownTokenRecord &&
-    ownVoterWeight?.hasMinAmountToVote(
-      ownTokenRecord.account.governingTokenMint
-    )
+    ownTokenRecord && communityOwnVoterWeight?.value?.gtn(0)
   const hasCouncilVoteWeight =
-    ownCouncilTokenRecord &&
-    ownVoterWeight?.hasMinAmountToVote(
-      ownCouncilTokenRecord.account.governingTokenMint
-    )
+    ownCouncilTokenRecord && councilOwnVoterWeight?.value?.gtn(0)
 
   const cantMultiVote =
     selectedProposals.length === 0 ||
@@ -277,8 +279,9 @@ const REALM = () => {
           realm.account.communityMint.toBase58()
             ? ownTokenRecord
             : ownCouncilTokenRecord
-        const role = selectedProposal.proposal.governingTokenMint.toBase58() ===
-            realm.account.communityMint.toBase58()
+        const role =
+          selectedProposal.proposal.governingTokenMint.toBase58() ===
+          realm.account.communityMint.toBase58()
             ? 'community'
             : 'council'
 

--- a/pages/dao/[symbol]/proposal/components/NewProposalBtn.tsx
+++ b/pages/dao/[symbol]/proposal/components/NewProposalBtn.tsx
@@ -2,12 +2,10 @@ import Link from 'next/link'
 import { PlusCircleIcon } from '@heroicons/react/outline'
 import useQueryContext from '@hooks/useQueryContext'
 import useRealm from '@hooks/useRealm'
-import { useMemo } from 'react'
 import Tooltip from '@components/Tooltip'
 import useWalletOnePointOh from '@hooks/useWalletOnePointOh'
 import { useRealmQuery } from '@hooks/queries/realm'
-import { useRealmGovernancesQuery } from '@hooks/queries/governance'
-import { useLegacyVoterWeight } from '@hooks/queries/governancePower'
+import { useRealmVoterWeightPlugins } from '@hooks/useRealmVoterWeightPlugins'
 
 const NewProposalBtn = () => {
   const { fmtUrlWithCluster } = useQueryContext()
@@ -16,32 +14,35 @@ const NewProposalBtn = () => {
   const connected = !!wallet?.connected
 
   const realm = useRealmQuery().data?.result
-  const { result: ownVoterWeight } = useLegacyVoterWeight()
+  // const { result: ownVoterWeight } = useLegacyVoterWeight()
+  const {
+    ownVoterWeight: communityOwnVoterWeight,
+  } = useRealmVoterWeightPlugins('community')
+  const {
+    isReady,
+    ownVoterWeight: councilOwnVoterWeight,
+  } = useRealmVoterWeightPlugins('council')
   const {
     symbol,
     toManyCommunityOutstandingProposalsForUser,
     toManyCouncilOutstandingProposalsForUse,
   } = useRealm()
 
-  const governancesQuery = useRealmGovernancesQuery()
-  const governanceItems = useMemo(() => governancesQuery.data ?? [], [
-    governancesQuery.data,
-  ])
+  const hasVotingPower =
+    (communityOwnVoterWeight && communityOwnVoterWeight.value?.gtn(0)) ||
+    (councilOwnVoterWeight && councilOwnVoterWeight.value?.gtn(0))
+
   const canCreateProposal =
     realm &&
-    governanceItems.some((g) =>
-      ownVoterWeight?.canCreateProposal(g.account.config)
-    ) &&
+    hasVotingPower &&
     !toManyCommunityOutstandingProposalsForUser &&
     !toManyCouncilOutstandingProposalsForUse
 
   const tooltipContent = !connected
     ? 'Connect your wallet to create new proposal'
-    : governanceItems.length === 0
+    : isReady && !communityOwnVoterWeight && !councilOwnVoterWeight
     ? 'There is no governance configuration to create a new proposal'
-    : !governanceItems.some((g) =>
-        ownVoterWeight?.canCreateProposal(g.account.config)
-      )
+    : !hasVotingPower
     ? "You don't have enough governance power to create a new proposal"
     : toManyCommunityOutstandingProposalsForUser
     ? 'Too many community outstanding proposals. You need to finalize them before creating a new one.'


### PR DESCRIPTION
When the delegate has at least one delegator wallet with power but no power on its own wallet, the "New Proposal" and batch voting are enabled, causing an error when he tries to perform these actions. This PR fixes the issue by disabling the buttons it was before the QV feature.