### PR TITLE
add "join" btn to token-haver

### DIFF
--- a/DriftStakeVoterPlugin/components/DriftVotingPower.tsx
+++ b/DriftStakeVoterPlugin/components/DriftVotingPower.tsx
@@ -79,7 +79,7 @@ export default function DriftVotingPower({ role, className }: Props) {
   // This latter case may occur if the DAO changes its configuration and new Voter Weight Records are required.
   // For example if a new plugin is added.
   const showJoinButton =
-    !userNeedsTokenOwnerRecord && userNeedsVoterWeightRecords
+    userNeedsTokenOwnerRecord || userNeedsVoterWeightRecords
 
   const join = async () => {
     const instructions = await handleRegister()


### PR DESCRIPTION
when a user has no token owner record or voter weight record, we show a button to have them create one. this adds this to the GREED dao plugin ui.

however, this also seems crazy? why not just do this automatically upon taking actions?