### PR TITLE
Fix: VoterWeightPks are not retrieved after wallet is connected

### DIFF
--- a/VoterWeightPlugins/hooks/useVoterWeightPks.ts
+++ b/VoterWeightPlugins/hooks/useVoterWeightPks.ts
@@ -45,4 +45,7 @@ export const useVoterWeightPks = (args: Args): UseAsyncReturn<{
             voterWeightPks,
             maxVoterWeightPk
         }
-    }, [args.plugins?.length, args.walletPublicKeys?.length]);
+    }, [
+        args.plugins?.length,
+        args.walletPublicKeys?.map((pk) => pk.toBase58()).join(','),
+      ])

--- a/VoterWeightPlugins/hooks/useVoterWeightPks.ts
+++ b/VoterWeightPlugins/hooks/useVoterWeightPks.ts
@@ -1,48 +1,77 @@
-import {UseVoterWeightPluginsArgs, VoterWeightPluginInfo} from "../lib/types";
-import {PublicKey} from "@solana/web3.js";
-import {getTokenOwnerRecordAddressSync} from "../lib/utils";
-import {useAsync, UseAsyncReturn} from "react-async-hook";
+import { UseVoterWeightPluginsArgs, VoterWeightPluginInfo } from '../lib/types'
+import { PublicKey } from '@solana/web3.js'
+import { getTokenOwnerRecordAddressSync } from '../lib/utils'
+import { useAsync, UseAsyncReturn } from 'react-async-hook'
 
 type Args = UseVoterWeightPluginsArgs & {
-    plugins?: VoterWeightPluginInfo[]
+  plugins?: VoterWeightPluginInfo[]
 }
 
 const argsAreSet = (args: Args): args is Required<Args> =>
-    args.realmPublicKey !== undefined && args.governanceMintPublicKey !== undefined && args.walletPublicKeys !== undefined &&
-    args.plugins !== undefined
+  args.realmPublicKey !== undefined &&
+  args.governanceMintPublicKey !== undefined &&
+  args.walletPublicKeys !== undefined &&
+  args.plugins !== undefined
 
-export const useVoterWeightPks = (args: Args): UseAsyncReturn<{
-    voterWeightPks: PublicKey[] | undefined,
-    maxVoterWeightPk: PublicKey | undefined
+export const useVoterWeightPks = (
+  args: Args
+): UseAsyncReturn<{
+  voterWeightPks: PublicKey[] | undefined
+  maxVoterWeightPk: PublicKey | undefined
 }> =>
-    useAsync(async () => {
-        // still loading
-        if (!argsAreSet(args)) return {
-            voterWeightPks: undefined,
-            maxVoterWeightPk: undefined
-        };
+  useAsync(async () => {
+    // still loading
+    if (!argsAreSet(args))
+      return {
+        voterWeightPks: undefined,
+        maxVoterWeightPk: undefined,
+      }
 
-        const {realmPublicKey, governanceMintPublicKey, walletPublicKeys, plugins} = args;
+    const {
+      realmPublicKey,
+      governanceMintPublicKey,
+      walletPublicKeys,
+      plugins,
+    } = args
 
-        // no plugins - return the token owner record and null
-        if (plugins.length === 0) {
-            const tokenOwnerRecords = walletPublicKeys.map(walletPublicKey => getTokenOwnerRecordAddressSync(realmPublicKey, governanceMintPublicKey, walletPublicKey));
-            return {
-                voterWeightPks: tokenOwnerRecords.map(([tokenOwnerRecord]) => tokenOwnerRecord),
-                maxVoterWeightPk: undefined
-            }
-        }
+    // no plugins - return the token owner record and null
+    if (plugins.length === 0) {
+      const tokenOwnerRecords = walletPublicKeys.map((walletPublicKey) =>
+        getTokenOwnerRecordAddressSync(
+          realmPublicKey,
+          governanceMintPublicKey,
+          walletPublicKey
+        )
+      )
+      return {
+        voterWeightPks: tokenOwnerRecords.map(
+          ([tokenOwnerRecord]) => tokenOwnerRecord
+        ),
+        maxVoterWeightPk: undefined,
+      }
+    }
 
-        const lastPlugin = plugins[plugins.length - 1];
+    const lastPlugin = plugins[plugins.length - 1]
 
-        const voterWeightPks = await Promise.all(walletPublicKeys.map(walletPublicKey =>
-            lastPlugin.client.getVoterWeightRecordPDA(realmPublicKey, governanceMintPublicKey, walletPublicKey)
-                .then(pda => pda.voterWeightPk)
-        ));
-        const {maxVoterWeightPk} = await lastPlugin.client.getMaxVoterWeightRecordPDA(realmPublicKey, governanceMintPublicKey) || {};
+    const voterWeightPks = await Promise.all(
+      walletPublicKeys.map((walletPublicKey) =>
+        lastPlugin.client
+          .getVoterWeightRecordPDA(
+            realmPublicKey,
+            governanceMintPublicKey,
+            walletPublicKey
+          )
+          .then((pda) => pda.voterWeightPk)
+      )
+    )
+    const { maxVoterWeightPk } =
+      (await lastPlugin.client.getMaxVoterWeightRecordPDA(
+        realmPublicKey,
+        governanceMintPublicKey
+      )) || {}
 
-        return {
-            voterWeightPks,
-            maxVoterWeightPk
-        }
-    }, []);
+    return {
+      voterWeightPks,
+      maxVoterWeightPk,
+    }
+  }, [args.plugins?.length, args.walletPublicKeys?.length])

--- a/VoterWeightPlugins/hooks/useVoterWeightPks.ts
+++ b/VoterWeightPlugins/hooks/useVoterWeightPks.ts
@@ -1,77 +1,48 @@
-import { UseVoterWeightPluginsArgs, VoterWeightPluginInfo } from '../lib/types'
-import { PublicKey } from '@solana/web3.js'
-import { getTokenOwnerRecordAddressSync } from '../lib/utils'
-import { useAsync, UseAsyncReturn } from 'react-async-hook'
+import {UseVoterWeightPluginsArgs, VoterWeightPluginInfo} from "../lib/types";
+import {PublicKey} from "@solana/web3.js";
+import {getTokenOwnerRecordAddressSync} from "../lib/utils";
+import {useAsync, UseAsyncReturn} from "react-async-hook";
 
 type Args = UseVoterWeightPluginsArgs & {
-  plugins?: VoterWeightPluginInfo[]
+    plugins?: VoterWeightPluginInfo[]
 }
 
 const argsAreSet = (args: Args): args is Required<Args> =>
-  args.realmPublicKey !== undefined &&
-  args.governanceMintPublicKey !== undefined &&
-  args.walletPublicKeys !== undefined &&
-  args.plugins !== undefined
+    args.realmPublicKey !== undefined && args.governanceMintPublicKey !== undefined && args.walletPublicKeys !== undefined &&
+    args.plugins !== undefined
 
-export const useVoterWeightPks = (
-  args: Args
-): UseAsyncReturn<{
-  voterWeightPks: PublicKey[] | undefined
-  maxVoterWeightPk: PublicKey | undefined
+export const useVoterWeightPks = (args: Args): UseAsyncReturn<{
+    voterWeightPks: PublicKey[] | undefined,
+    maxVoterWeightPk: PublicKey | undefined
 }> =>
-  useAsync(async () => {
-    // still loading
-    if (!argsAreSet(args))
-      return {
-        voterWeightPks: undefined,
-        maxVoterWeightPk: undefined,
-      }
+    useAsync(async () => {
+        // still loading
+        if (!argsAreSet(args)) return {
+            voterWeightPks: undefined,
+            maxVoterWeightPk: undefined
+        };
 
-    const {
-      realmPublicKey,
-      governanceMintPublicKey,
-      walletPublicKeys,
-      plugins,
-    } = args
+        const {realmPublicKey, governanceMintPublicKey, walletPublicKeys, plugins} = args;
 
-    // no plugins - return the token owner record and null
-    if (plugins.length === 0) {
-      const tokenOwnerRecords = walletPublicKeys.map((walletPublicKey) =>
-        getTokenOwnerRecordAddressSync(
-          realmPublicKey,
-          governanceMintPublicKey,
-          walletPublicKey
-        )
-      )
-      return {
-        voterWeightPks: tokenOwnerRecords.map(
-          ([tokenOwnerRecord]) => tokenOwnerRecord
-        ),
-        maxVoterWeightPk: undefined,
-      }
-    }
+        // no plugins - return the token owner record and null
+        if (plugins.length === 0) {
+            const tokenOwnerRecords = walletPublicKeys.map(walletPublicKey => getTokenOwnerRecordAddressSync(realmPublicKey, governanceMintPublicKey, walletPublicKey));
+            return {
+                voterWeightPks: tokenOwnerRecords.map(([tokenOwnerRecord]) => tokenOwnerRecord),
+                maxVoterWeightPk: undefined
+            }
+        }
 
-    const lastPlugin = plugins[plugins.length - 1]
+        const lastPlugin = plugins[plugins.length - 1];
 
-    const voterWeightPks = await Promise.all(
-      walletPublicKeys.map((walletPublicKey) =>
-        lastPlugin.client
-          .getVoterWeightRecordPDA(
-            realmPublicKey,
-            governanceMintPublicKey,
-            walletPublicKey
-          )
-          .then((pda) => pda.voterWeightPk)
-      )
-    )
-    const { maxVoterWeightPk } =
-      (await lastPlugin.client.getMaxVoterWeightRecordPDA(
-        realmPublicKey,
-        governanceMintPublicKey
-      )) || {}
+        const voterWeightPks = await Promise.all(walletPublicKeys.map(walletPublicKey =>
+            lastPlugin.client.getVoterWeightRecordPDA(realmPublicKey, governanceMintPublicKey, walletPublicKey)
+                .then(pda => pda.voterWeightPk)
+        ));
+        const {maxVoterWeightPk} = await lastPlugin.client.getMaxVoterWeightRecordPDA(realmPublicKey, governanceMintPublicKey) || {};
 
-    return {
-      voterWeightPks,
-      maxVoterWeightPk,
-    }
-  }, [args.plugins?.length, args.walletPublicKeys?.length])
+        return {
+            voterWeightPks,
+            maxVoterWeightPk
+        }
+    }, [args.plugins?.length, args.walletPublicKeys?.length]);


### PR DESCRIPTION
Fix the issue when you connect your wallet, change it, or select a different delegate wallet, the Voter Weight Pks are not properly updated in the hook.