### PR TITLE
Correct the `exists` function to properly check both null and undefined

### DIFF
--- a/pages/dao/[symbol]/proposal/components/GovernedAccountSelect.tsx
+++ b/pages/dao/[symbol]/proposal/components/GovernedAccountSelect.tsx
@@ -34,7 +34,7 @@ import MintIcon from '@components/treasuryV2/icons/MintIcon'
 import { getAccountName } from '@components/instructions/tools'
 
 function exists<T>(item: T | null | undefined): item is T {
-  return item !== null || item !== undefined
+  return item !== null && item !== undefined
 }
 
 function RulesPill(props: { icon: JSX.Element; value: string; label: string }) {


### PR DESCRIPTION
This PR fixes a bug in the `exists` function within the `GovernedAccountSelect` component, which previously returned `true` when the `item` is `undefined`.