### PR TITLE
Fix the start unlock error

### DIFF
--- a/VoteStakeRegistry/components/Account/LockTokensModal.tsx
+++ b/VoteStakeRegistry/components/Account/LockTokensModal.tsx
@@ -179,7 +179,7 @@ const LockTokensModal = ({
         ? getMintDecimalAmount(
             mint,
             depositRecord?.amountDepositedNative.add(
-              new BN(realmTokenAccount?.account.amount)
+              new BN(realmTokenAccount?.account.amount ?? 0)
             )
           )
         : getMintDecimalAmount(mint, depositRecord?.amountDepositedNative)
@@ -191,7 +191,7 @@ const LockTokensModal = ({
         ? fmtMintAmount(
             mint,
             depositRecord?.amountDepositedNative.add(
-              new BN(realmTokenAccount?.account.amount)
+              new BN(realmTokenAccount?.account.amount ?? 0)
             )
           )
         : fmtMintAmount(mint, depositRecord?.amountDepositedNative)
@@ -276,7 +276,7 @@ const LockTokensModal = ({
       lockUpPeriodInDays: lockupPeriodDays,
       lockupKind: lockupType.value,
       sourceDepositIdx: depositRecord!.index,
-      sourceTokenAccount: realmTokenAccount?.publicKey,
+      sourceTokenAccount: realmTokenAccount!.publicKey,
       allowClawback: allowClawback,
       tokenOwnerRecordPk,
       client: client,

--- a/VoteStakeRegistry/components/Account/LockTokensModal.tsx
+++ b/VoteStakeRegistry/components/Account/LockTokensModal.tsx
@@ -179,7 +179,7 @@ const LockTokensModal = ({
         ? getMintDecimalAmount(
             mint,
             depositRecord?.amountDepositedNative.add(
-              new BN(realmTokenAccount!.account.amount)
+              new BN(realmTokenAccount?.account.amount)
             )
           )
         : getMintDecimalAmount(mint, depositRecord?.amountDepositedNative)
@@ -191,7 +191,7 @@ const LockTokensModal = ({
         ? fmtMintAmount(
             mint,
             depositRecord?.amountDepositedNative.add(
-              new BN(realmTokenAccount!.account.amount)
+              new BN(realmTokenAccount?.account.amount)
             )
           )
         : fmtMintAmount(mint, depositRecord?.amountDepositedNative)
@@ -276,7 +276,7 @@ const LockTokensModal = ({
       lockUpPeriodInDays: lockupPeriodDays,
       lockupKind: lockupType.value,
       sourceDepositIdx: depositRecord!.index,
-      sourceTokenAccount: realmTokenAccount!.publicKey,
+      sourceTokenAccount: realmTokenAccount?.publicKey,
       allowClawback: allowClawback,
       tokenOwnerRecordPk,
       client: client,


### PR DESCRIPTION
When the user tries to unlock their tokens.

![image](https://github.com/user-attachments/assets/6c0bcefc-33bf-4a12-a1dc-1675c3068d5a)

They get this error:

![image](https://github.com/user-attachments/assets/c17a79ce-d840-4d65-8178-2f2b2f832da6)

There was a force check `!` of an undefined value, I changed it to a soft check `?`.
This will just wait for the component to load the `realmTokenAccount`
