### PR TITLE
Updated jup token fetch to directly load unverified tokens

### DIFF
--- a/hooks/useTreasuryInfo/convertAccountToAsset.tsx
+++ b/hooks/useTreasuryInfo/convertAccountToAsset.tsx
@@ -2,7 +2,7 @@ import { BigNumber } from 'bignumber.js'
 
 import { AccountType, AssetAccount } from '@utils/uiTypes/assets'
 import { AssetType, Asset } from '@models/treasury/Asset'
-import { getTreasuryAccountItemInfoV2 } from '@utils/treasuryTools'
+import { getTreasuryAccountItemInfoV2Async } from '@utils/treasuryTools'
 import TokenIcon from '@components/treasuryV2/icons/TokenIcon'
 import { WSOL_MINT } from '@components/instructions/tools'
 import { abbreviateAddress } from '@utils/formatting'
@@ -16,7 +16,7 @@ export const convertAccountToAsset = async (
   councilMintAddress?: string,
   communityMintAddress?: string
 ): Promise<Asset | null> => {
-  const info = getTreasuryAccountItemInfoV2(account)
+  const info = await getTreasuryAccountItemInfoV2Async(account)
 
   switch (account.type) {
     case AccountType.AUXILIARY_TOKEN:

--- a/utils/services/tokenPrice.tsx
+++ b/utils/services/tokenPrice.tsx
@@ -151,10 +151,7 @@ class TokenPriceService {
 
       return finalTokenInfo;
     } else {
-      notify({
-        type: 'error',
-        message: 'Token data could not be retrieved',
-      });
+      console.error(`Metadata retrieving failed for ${mintAddress}`);
       return undefined;
     }
   } catch (e) {

--- a/utils/services/tokenPrice.tsx
+++ b/utils/services/tokenPrice.tsx
@@ -12,6 +12,7 @@ import { USDC_MINT } from '@blockworks-foundation/mango-v4'
 //decimals from metadata can be different from the realm on chain one
 const priceEndpoint = 'https://price.jup.ag/v4/price'
 const tokenListUrl = 'https://token.jup.ag/strict'
+//const tokenListUrl = 'https://tokens.jup.ag/tokens' // The full list is available but takes much longer to load
 
 export type TokenInfoWithoutDecimals = Omit<TokenInfo, 'decimals'>
 
@@ -21,9 +22,11 @@ class TokenPriceService {
   _tokenPriceToUSDlist: {
     [mintAddress: string]: Price
   }
+  _unverifiedTokenCache: { [mintAddress: string]: TokenInfoWithoutDecimals };
   constructor() {
     this._tokenList = []
     this._tokenPriceToUSDlist = {}
+    this._unverifiedTokenCache = {}
   }
   async fetchSolanaTokenList() {
     try {
@@ -113,6 +116,53 @@ class TokenPriceService {
       (x) => x.address === mintAddress
     )
     return tokenListRecord
+  }
+
+  // This async method is used to lookup additional tokens not on JUP's strict list
+  async getTokenInfoAsync(mintAddress: string): Promise<TokenInfoWithoutDecimals | undefined> {
+    if (!mintAddress || mintAddress.trim() === '') {
+      return undefined;
+    }
+    // Check the strict token list first
+    let tokenListRecord = this._tokenList?.find((x) => x.address === mintAddress);
+    if (tokenListRecord) {
+      return tokenListRecord;
+    }
+
+    // Check the unverified token list cache next to avoid repeatedly loading token metadata
+    if (this._unverifiedTokenCache[mintAddress]) {
+      return this._unverifiedTokenCache[mintAddress];
+    }
+
+    // Get the token data from JUP's api
+    const requestURL = `https://tokens.jup.ag/token/${mintAddress}`
+    const response = await axios.get(requestURL);
+
+    if (response.data) {
+      // Remove decimals and add chainId to match the TokenInfoWithoutDecimals struct
+      const { decimals, ...tokenInfoWithoutDecimals } = response.data;
+      const finalTokenInfo = {
+        ...tokenInfoWithoutDecimals,
+        chainId: 101
+      };
+
+      // Add to unverified token cache
+      this._unverifiedTokenCache[mintAddress] = finalTokenInfo;
+
+      return finalTokenInfo;
+    } else {
+      notify({
+        type: 'error',
+        message: 'Token data could not be retrieved',
+      });
+      return undefined;
+    }
+  } catch (e) {
+    notify({
+      type: 'error',
+      message: 'Unable to fetch token information',
+    });
+    return undefined;
   }
   /**
    * For decimals use on chain tryGetMint

--- a/utils/treasuryTools.tsx
+++ b/utils/treasuryTools.tsx
@@ -69,3 +69,67 @@ export const getTreasuryAccountItemInfoV2 = (account: AssetAccount) => {
     totalPrice,
   }
 }
+
+//This async method added to add a lookup for token metadata not available in JUP's strict list
+export const getTreasuryAccountItemInfoV2Async = async (account: AssetAccount) => {
+  const mintAddress =
+    account.type === AccountType.SOL
+      ? WSOL_MINT
+      : account.extensions.mint?.publicKey.toBase58()
+
+  const amount =
+    account.extensions.amount && account.extensions.mint
+      ? getMintDecimalAmountFromNatural(
+          account.extensions.mint.account,
+          new BN(
+            account.isSol
+              ? account.extensions.solAccount!.lamports
+              : account.extensions.amount
+          )
+        ).toNumber()
+      : 0
+  const price = tokenPriceService.getUSDTokenPrice(mintAddress!)
+  const totalPrice = amount * price
+  const totalPriceFormatted = amount
+    ? new BigNumber(totalPrice).toFormat(0)
+    : ''
+  const info = await tokenPriceService.getTokenInfoAsync(mintAddress!)
+
+  const symbol =
+    account.type === AccountType.NFT
+      ? 'NFTS'
+      : account.type === AccountType.SOL
+      ? 'SOL'
+      : info?.symbol
+      ? info.address === WSOL_MINT
+        ? 'wSOL'
+        : info?.symbol
+      : account.extensions.mint
+      ? abbreviateAddress(account.extensions.mint.publicKey)
+      : ''
+  const amountFormatted = new BigNumber(amount).toFormat()
+
+  const logo = info?.logoURI || ''
+  const accountName = account.pubkey ? getAccountName(account.pubkey) : ''
+  const name = accountName
+    ? accountName
+    : account.extensions.transferAddress
+    ? abbreviateAddress(account.extensions.transferAddress as PublicKey)
+    : ''
+
+  const displayPrice =
+    totalPriceFormatted && totalPriceFormatted !== '0'
+      ? totalPriceFormatted
+      : ''
+
+  return {
+    accountName,
+    amountFormatted,
+    logo,
+    name,
+    displayPrice,
+    info,
+    symbol,
+    totalPrice,
+  }
+}


### PR DESCRIPTION
Created in relation to gib.work request: https://v2.gib.work/tasks/0e250d38-b646-41a6-b5e9-913964701416

The core issue is the lookup for token data is just using jup's strict token list, leaving out metadata for many governance tokens.

I designed three potential fixes:

1. Swap from strict to full token list (this will add some loading time, but could perhaps be further enhanced to cache some of that info instead)
2. Swap to do a direct token metadata lookup instead of using the token list at all
3. Do a hybrid, where the strict list is loaded, and then if any token is missing from it a direct lookup is used instead

I decided that ultimately 3 would be the best solution, but this added the additional need of an async call for getTokenInfo(). If the team would prefer I pursue 1 or 2 instead, I will revise my PR.

To resolve this without making major structural changes, I added a new function in tokenPrice.tsx, getTokenInfoAsync(), which works as follows:

1. Check if the token is on the strict list, and if so load from there
2. Check if the token metadata has been added to the unverified token cache, and if so load from there
3. If not, use jup's api to get the individual token metadata
4. Restructure the response data to match the TokenInfoWithoutDecimals struct
5. Save to the unverified token cache
6. Return the token metadata

This of course also necessitated a new async getTreasuryAccountItemInfoV2Async() in treasuryTools.tsx

These changes together create a simple fallback for tokens not on the strict list to be automatically visible in Realms. I only updated from getTreasuryAccountItemInfoV2 --> getTreasuryAccountItemInfoV2Async on the convertAccountToAsset.tsx file, but the same change can easily be added to other uses of it if it is decided to be implemented.

Also, just to state it, the strict token list are generally accepted tokens, by allowing any token data to be loaded, a bad actor could send a distasteful token to a treasury, then show it as a DAO holding for potentially bad PR. I think this is low probability, and likely would be ignored by web3 people if something like that occurred, but still worthwhile to consider.
