### PR TITLE
Change "Epicentral Labs DAO" to "EpicentralDAO"

### DIFF
--- a/public/realms/mainnet-beta.json
+++ b/public/realms/mainnet-beta.json
@@ -3607,7 +3607,7 @@
     "symbol": "LABS",
     "category": "defi",
     "bannerImage": "/realms/EpicentralLabsDAO/EpicentralDAOBanner.png",
-    "displayName": "Epicentral Labs DAO",
+    "displayName": "EpicentralDAO",
     "programId": "GovER5Lthms3bLBqWub97yVrMmEogzX7xNjdXpPPCVZw",
     "realmId": "5PP7vKjJyLw1MR55LoexRsCj3CpZj9MdD6aNXRrvxG42",
     "communityMint": "LABSh5DTebUcUbEoLzXKCiXFJLecDFiDWiBGUU1GpxR",


### PR DESCRIPTION
Shortening the DAO name for simplicity reasons.